### PR TITLE
Fix #7: implement grounded Supplie second panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,24 +2,29 @@
 
 ## Current Architecture
 
-- This is currently a **single-backend slice**.
+- This is now a **two-agent demo slice**.
 - The frontend keeps the two-panel comparison layout.
-- Both panels render the same shared LangChain session.
-- The backend represents the **ungrounded** agent from the demo design.
+- The left panel runs the **ungrounded / raw** LangChain agent.
+- The right panel runs the **grounded Supplie** agent with built-in demo tools.
 
 ## Supported Today
 
 - OpenAI and Anthropic model selection
 - Streamed text responses
+- Right-panel Supplie demo snapshot tools for:
+  - order margin lookup with freight and rebates
+  - 30-day stockout risk checks
+  - supplier margin leakage ranking
 - Honest capability disclosure when the user asks for unsupported actions
 
 ## Not Supported Yet
 
+- Live ERP / warehouse access
 - Native web search
 - Code sandbox execution
 - File access or generated file downloads
 
-These capabilities should stay disabled in UI and backend code until real tool implementations exist.
+The grounded panel uses a static bundled demo snapshot. It must not imply live operational access until real Supplie integrations exist.
 
 ## Env Vars
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # Supplie Demo
 
-This repo is a Next.js demo frontend with a single LangChain-backed backend agent.
+This repo is a Next.js demo frontend with two LangChain-backed demo agents.
 
 ## Current Slice
 
 - The UI keeps the two-panel side-by-side demo layout.
-- Both panels mirror the same shared backend session.
-- The backend is an **ungrounded** LangChain agent.
-- Streaming text is supported.
-- Native web search, code sandbox, and file access are **not wired yet**.
+- The left panel is an **ungrounded / raw** LangChain agent.
+- The right panel is a **grounded Supplie** agent backed by built-in demo tools.
+- Streaming text is supported on both sides.
+- The grounded side uses a static bundled Supplie demo snapshot, not live production data.
+- Native web search, code sandbox, live ERP access, and file access are **not wired yet**.
 
-The agent is instructed to say when required data or capabilities are missing instead of pretending they exist.
+Both agents are instructed to say when required data or capabilities are missing instead of pretending they exist.
 
 ## Local Development
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,6 +1,7 @@
 import { AIMessageChunk } from "@langchain/core/messages";
 import { NextResponse } from "next/server";
 import { checkRateLimit } from "@/lib/server/rate-limit";
+import { getGroundedAgent } from "@/lib/server/grounded-agent";
 import {
   encodeDone,
   encodeError,
@@ -9,9 +10,9 @@ import {
 } from "@/lib/server/stream-protocol";
 import {
   assertProviderIsConfigured,
-  DemoProvider,
   getUngroundedAgent,
 } from "@/lib/server/ungrounded-agent";
+import { DEMO_PANEL_CONFIGS, type DemoAgentMode, type DemoProvider } from "@/lib/server/demo-config";
 
 export const runtime = "nodejs";
 export const maxDuration = 120;
@@ -20,6 +21,7 @@ interface ChatRequestBody {
   prompt?: string;
   model?: string;
   provider?: DemoProvider;
+  agentMode?: DemoAgentMode;
   messages?: Array<{
     role?: string;
     content?: string;
@@ -105,6 +107,7 @@ export async function POST(req: Request) {
   const body = (await req.json()) as ChatRequestBody;
   const model = body.model ?? "gpt-5.4-mini-2026-03-17";
   const provider = body.provider ?? "openai";
+  const agentMode = body.agentMode ?? "ungrounded";
   const messages = normalizeMessages(body);
 
   if (messages.length === 0) {
@@ -123,13 +126,18 @@ export async function POST(req: Request) {
   }
 
   const startMs = Date.now();
-  const agent = getUngroundedAgent({ model, provider });
+  const agent =
+    agentMode === "grounded"
+      ? getGroundedAgent({ model, provider })
+      : getUngroundedAgent({ model, provider });
+  const backendLabel = DEMO_PANEL_CONFIGS[agentMode].backendLabel;
 
   console.log(
     JSON.stringify({
       event: "request_start",
       route: "chat",
-      backend: "langchain-ungrounded-agent",
+      backend: backendLabel,
+      agent_mode: agentMode,
       provider,
       model,
       timestamp: new Date().toISOString(),
@@ -195,7 +203,8 @@ export async function POST(req: Request) {
           JSON.stringify({
             event: "request_complete",
             route: "chat",
-            backend: "langchain-ungrounded-agent",
+            backend: backendLabel,
+            agent_mode: agentMode,
             provider,
             model,
             total_ms: Date.now() - startMs,
@@ -210,7 +219,8 @@ export async function POST(req: Request) {
           JSON.stringify({
             event: "request_error",
             route: "chat",
-            backend: "langchain-ungrounded-agent",
+            backend: backendLabel,
+            agent_mode: agentMode,
             provider,
             model,
             message,

--- a/app/api/config/route.ts
+++ b/app/api/config/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getPublicDemoConfig } from "@/lib/server/ungrounded-agent";
+import { getPublicDemoConfig } from "@/lib/server/demo-config";
 
 export const runtime = "nodejs";
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,15 +9,132 @@ import { useStreamingChat } from "@/hooks/useStreamingChat";
 
 interface DemoConfig {
   anthropicAvailable: boolean;
-  backendLabel: string;
-  sharedAcrossPanels: boolean;
-  capabilities: Array<{
-    id: string;
-    label: string;
-    enabled: boolean;
-    availability: "available" | "planned";
+  comparisonMode: string;
+  sharedLimitations: string[];
+  panels: Array<{
+    id: "ungrounded" | "grounded";
+    title: string;
+    badge: string;
+    badgeColor: "amber" | "teal";
+    backendLabel: string;
     description: string;
+    emptyStateTitle: string;
+    emptyStateDetail: string;
+    capabilities: Array<{
+      id: string;
+      label: string;
+      enabled: boolean;
+      availability: "available" | "planned";
+      description: string;
+    }>;
   }>;
+}
+
+const DEFAULT_CONFIG: Omit<DemoConfig, "anthropicAvailable"> = {
+  comparisonMode: "dual-agent",
+  sharedLimitations: [
+    "No live ERP or warehouse connectivity.",
+    "No native web search.",
+    "No code sandbox.",
+    "No file access or downloads.",
+  ],
+  panels: [
+    {
+      id: "ungrounded",
+      title: "Ungrounded / Raw Agent",
+      badge: "Reasoning only",
+      badgeColor: "amber",
+      backendLabel: "LangChain ungrounded agent",
+      description:
+        "Answers from general reasoning only. No grounded Supplie data tools are available on this side.",
+      emptyStateTitle: "Raw reasoning appears here",
+      emptyStateDetail:
+        "This panel stays ungrounded and should disclose when a question needs real data or tools.",
+      capabilities: [
+        {
+          id: "streaming_text",
+          label: "Streaming responses",
+          enabled: true,
+          availability: "available",
+          description: "LangChain agent text streaming is live in this slice.",
+        },
+      ],
+    },
+    {
+      id: "grounded",
+      title: "Grounded Supplie Agent",
+      badge: "Supplie tools",
+      badgeColor: "teal",
+      backendLabel: "Supplie grounded demo agent",
+      description:
+        "Uses built-in Supplie demo tools against a static bundled snapshot. No live ERP, browsing, code execution, or file access.",
+      emptyStateTitle: "Grounded tool-backed answers appear here",
+      emptyStateDetail:
+        "This panel can query the bundled Supplie demo snapshot and should say when a question falls outside that data.",
+      capabilities: [
+        {
+          id: "streaming_text",
+          label: "Streaming responses",
+          enabled: true,
+          availability: "available",
+          description: "LangChain agent text streaming is live in this slice.",
+        },
+        {
+          id: "supplie_demo_tools",
+          label: "Supplie demo snapshot tools",
+          enabled: true,
+          availability: "available",
+          description:
+            "The grounded panel can query built-in Supplie demo data tools against a static snapshot bundled with this app.",
+        },
+      ],
+    },
+  ],
+};
+
+interface DemoCapability {
+  id: string;
+  label: string;
+  enabled: boolean;
+  availability: "available" | "planned";
+  description: string;
+}
+
+interface DemoPanelConfig {
+  id: "ungrounded" | "grounded";
+  title: string;
+  badge: string;
+  badgeColor: "amber" | "teal";
+  backendLabel: string;
+  description: string;
+  emptyStateTitle: string;
+  emptyStateDetail: string;
+  capabilities: DemoCapability[];
+}
+
+function formatCapabilityList(capabilities: DemoCapability[]) {
+  const enabled = capabilities.filter((capability) => capability.enabled);
+  return enabled.length > 0
+    ? enabled.map((capability) => capability.label).join(", ")
+    : "No runtime capabilities are enabled.";
+}
+
+function findPanelConfig(
+  config: DemoConfig | null,
+  panelId: DemoPanelConfig["id"],
+): DemoPanelConfig {
+  return (
+    config?.panels.find((panel) => panel.id === panelId) ??
+    DEFAULT_CONFIG.panels.find((panel) => panel.id === panelId)!
+  );
+}
+
+function getLastUserMessageContent(
+  messages: ReturnType<typeof useStreamingChat>["messages"],
+) {
+  return [...messages]
+    .reverse()
+    .find((message) => message.role === "user")?.content;
 }
 
 export default function Home() {
@@ -60,9 +177,19 @@ export default function Home() {
     [handleAuthError],
   );
 
-  const { messages, append, setMessages, isLoading, error } = useStreamingChat({
+  const ungroundedChat = useStreamingChat({
     api: "/api/chat",
-    body: { model, provider },
+    body: { model, provider, agentMode: "ungrounded" },
+    headers: useCallback(
+      () => ({ Authorization: `Bearer ${getToken()}` }),
+      [getToken],
+    ),
+    onError: handleChatError,
+  });
+
+  const groundedChat = useStreamingChat({
+    api: "/api/chat",
+    body: { model, provider, agentMode: "grounded" },
     headers: useCallback(
       () => ({ Authorization: `Bearer ${getToken()}` }),
       [getToken],
@@ -71,23 +198,32 @@ export default function Home() {
   });
 
   const handleClear = useCallback(() => {
-    setMessages([]);
-  }, [setMessages]);
+    ungroundedChat.stop();
+    groundedChat.stop();
+    ungroundedChat.setMessages([]);
+    groundedChat.setMessages([]);
+  }, [groundedChat, ungroundedChat]);
 
   const handleModelChange = useCallback(
     (modelId: string, newProvider: "openai" | "anthropic") => {
+      ungroundedChat.stop();
+      groundedChat.stop();
       setModel(modelId);
       setProvider(newProvider);
-      setMessages([]);
+      ungroundedChat.setMessages([]);
+      groundedChat.setMessages([]);
     },
-    [setMessages],
+    [groundedChat, ungroundedChat],
   );
 
   const handlePrompt = useCallback(
     (prompt: string) => {
-      append({ role: "user", content: prompt });
+      void Promise.allSettled([
+        ungroundedChat.append({ role: "user", content: prompt }),
+        groundedChat.append({ role: "user", content: prompt }),
+      ]);
     },
-    [append],
+    [groundedChat, ungroundedChat],
   );
 
   useEffect(() => {
@@ -97,40 +233,45 @@ export default function Home() {
       .catch(() => setConfig(null));
   }, []);
 
-  const handleRetry = useCallback(() => {
-    const lastUser = [...messages]
-      .reverse()
-      .find((message) => message.role === "user");
-    if (lastUser) {
-      append({ role: "user", content: lastUser.content });
-    }
-  }, [append, messages]);
+  const ungroundedPanel = useMemo(
+    () => findPanelConfig(config, "ungrounded"),
+    [config],
+  );
+  const groundedPanel = useMemo(
+    () => findPanelConfig(config, "grounded"),
+    [config],
+  );
 
-  const currentSliceMessage = useMemo(() => {
-    const availableCapabilities =
-      config?.capabilities.filter((capability) => capability.enabled) ?? [];
-    const plannedCapabilities =
-      config?.capabilities.filter((capability) => !capability.enabled) ?? [];
-
-    const availableText =
-      availableCapabilities.length > 0
-        ? availableCapabilities.map((capability) => capability.label).join(", ")
-        : "No runtime capabilities are enabled.";
-    const plannedText =
-      plannedCapabilities.length > 0
-        ? plannedCapabilities.map((capability) => capability.label).join(", ")
-        : "No planned capabilities listed.";
+  const comparisonMessage = useMemo(() => {
+    const sharedLimitations = (
+      config?.sharedLimitations ?? DEFAULT_CONFIG.sharedLimitations
+    ).join(" ");
 
     return {
-      availableText,
-      plannedText,
+      ungroundedCapabilities: formatCapabilityList(
+        ungroundedPanel.capabilities,
+      ),
+      groundedCapabilities: formatCapabilityList(groundedPanel.capabilities),
+      sharedLimitations,
     };
-  }, [config]);
+  }, [config, groundedPanel.capabilities, ungroundedPanel.capabilities]);
 
-  // Don't render anything until we've checked auth (avoids flash)
+  const handleRetryUngrounded = useCallback(() => {
+    const lastUser = getLastUserMessageContent(ungroundedChat.messages);
+    if (lastUser) {
+      void ungroundedChat.append({ role: "user", content: lastUser });
+    }
+  }, [ungroundedChat]);
+
+  const handleRetryGrounded = useCallback(() => {
+    const lastUser = getLastUserMessageContent(groundedChat.messages);
+    if (lastUser) {
+      void groundedChat.append({ role: "user", content: lastUser });
+    }
+  }, [groundedChat]);
+
   if (!authChecked) return null;
 
-  // Show password gate exclusively — no app behind it
   if (!authed) {
     return <PasswordGate onAuth={handleAuth} />;
   }
@@ -143,7 +284,6 @@ export default function Home() {
         fontFamily: "Inter, system-ui, sans-serif",
       }}
     >
-      {/* Top bar */}
       <div className="flex items-center gap-4 px-5 py-3 border-b border-white/5 flex-shrink-0">
         <div className="flex items-center gap-2">
           <div className="w-5 h-5 rounded bg-teal-500/20 flex items-center justify-center">
@@ -177,53 +317,61 @@ export default function Home() {
         </div>
       </div>
 
-      {/* Prompt buttons */}
-      <PromptButtons onPrompt={handlePrompt} />
+      <PromptButtons
+        onPrompt={handlePrompt}
+        disabled={ungroundedChat.isLoading || groundedChat.isLoading}
+      />
 
       <div className="px-5 py-3 border-b border-white/5 bg-slate-950/30">
         <div className="text-[11px] uppercase tracking-[0.18em] text-slate-500">
-          Current Slice
+          Live Comparison
         </div>
         <div className="mt-1 text-sm text-slate-200">
-          Both panels mirror the same{" "}
-          {config?.backendLabel ?? "LangChain ungrounded agent"} for now.
-          Streaming text is live, but the comparison UI is intentionally backed
-          by one shared session until grounded capabilities are implemented.
+          Left panel stays raw on {ungroundedPanel.backendLabel}. Right panel
+          runs {groundedPanel.backendLabel} with bundled Supplie snapshot tools.
         </div>
         <div className="mt-2 text-xs text-slate-400">
-          Available now: {currentSliceMessage.availableText}
+          Raw panel: {comparisonMessage.ungroundedCapabilities}
+        </div>
+        <div className="mt-1 text-xs text-teal-300">
+          Grounded panel: {comparisonMessage.groundedCapabilities}
         </div>
         <div className="mt-1 text-xs text-slate-500">
-          Not wired yet: {currentSliceMessage.plannedText}
+          Shared limits: {comparisonMessage.sharedLimitations}
         </div>
       </div>
 
-      {/* Two panels */}
       <div className="flex flex-1 overflow-hidden">
         <div className="w-1/2">
           <Panel
-            title="Ungrounded Agent"
-            badge="Shared backend"
-            badgeColor="amber"
+            title={ungroundedPanel.title}
+            badge={ungroundedPanel.badge}
+            badgeColor={ungroundedPanel.badgeColor}
             bgColor="var(--bg-amber-panel)"
             borderColor="border-amber-900/30"
-            messages={messages}
-            isLoading={isLoading}
-            error={error}
-            onRetry={handleRetry}
+            note={ungroundedPanel.description}
+            emptyStateTitle={ungroundedPanel.emptyStateTitle}
+            emptyStateDetail={ungroundedPanel.emptyStateDetail}
+            messages={ungroundedChat.messages}
+            isLoading={ungroundedChat.isLoading}
+            error={ungroundedChat.error}
+            onRetry={handleRetryUngrounded}
           />
         </div>
         <div className="w-1/2">
           <Panel
-            title="Ungrounded Agent Mirror"
-            badge="Shared backend"
-            badgeColor="teal"
+            title={groundedPanel.title}
+            badge={groundedPanel.badge}
+            badgeColor={groundedPanel.badgeColor}
             bgColor="var(--bg-teal-panel)"
             borderColor="border-teal-900/30"
-            messages={messages}
-            isLoading={isLoading}
-            error={error}
-            onRetry={handleRetry}
+            note={groundedPanel.description}
+            emptyStateTitle={groundedPanel.emptyStateTitle}
+            emptyStateDetail={groundedPanel.emptyStateDetail}
+            messages={groundedChat.messages}
+            isLoading={groundedChat.isLoading}
+            error={groundedChat.error}
+            onRetry={handleRetryGrounded}
           />
         </div>
       </div>

--- a/components/Panel.tsx
+++ b/components/Panel.tsx
@@ -10,6 +10,9 @@ interface PanelProps {
   badgeColor: "amber" | "teal";
   bgColor: string;
   borderColor: string;
+  note: string;
+  emptyStateTitle: string;
+  emptyStateDetail: string;
   messages: ChatMessage[];
   isLoading: boolean;
   error: Error | null;
@@ -22,6 +25,9 @@ export function Panel({
   badgeColor,
   bgColor,
   borderColor,
+  note,
+  emptyStateTitle,
+  emptyStateDetail,
   messages,
   isLoading,
   error,
@@ -72,20 +78,28 @@ export function Panel({
           </div>
         )}
       </div>
+      <div className="px-4 py-2 border-b border-white/5 bg-black/10">
+        <p className="text-xs leading-relaxed text-slate-400">{note}</p>
+      </div>
 
       <div className="flex-1 overflow-y-auto p-4 space-y-4">
         {messages.length === 0 && !error && (
           <div className="flex items-center justify-center h-full">
-            <p
-              className="text-sm text-center"
-              style={{ color: "var(--text-secondary)" }}
-            >
-              Start a prompt above to stream the shared agent here
+            <div className="text-center">
+              <p
+                className="text-sm"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                {emptyStateTitle}
+              </p>
               <br />
-              <span className="text-xs" style={{ color: "var(--text-muted)" }}>
-                both panels mirror the same backend response in this slice
+              <span
+                className="text-xs"
+                style={{ color: "var(--text-muted)" }}
+              >
+                {emptyStateDetail}
               </span>
-            </p>
+            </div>
           </div>
         )}
 

--- a/lib/server/demo-capabilities.ts
+++ b/lib/server/demo-capabilities.ts
@@ -1,5 +1,7 @@
 export type DemoCapabilityId =
   | "streaming_text"
+  | "supplie_demo_tools"
+  | "live_systems"
   | "native_web_search"
   | "code_sandbox"
   | "file_access";
@@ -12,13 +14,29 @@ export interface DemoCapability {
   description: string;
 }
 
-export const DEMO_CAPABILITIES: DemoCapability[] = [
+export const UNGROUNDED_CAPABILITIES: DemoCapability[] = [
   {
     id: "streaming_text",
     label: "Streaming responses",
     enabled: true,
     availability: "available",
     description: "LangChain agent text streaming is live in this slice.",
+  },
+  {
+    id: "supplie_demo_tools",
+    label: "Supplie demo snapshot tools",
+    enabled: false,
+    availability: "planned",
+    description:
+      "The raw panel does not use grounded Supplie tools and must answer from general reasoning only.",
+  },
+  {
+    id: "live_systems",
+    label: "Live ERP / warehouse access",
+    enabled: false,
+    availability: "planned",
+    description:
+      "No live operational systems are connected. Do not imply access to current Supplie data.",
   },
   {
     id: "native_web_search",
@@ -46,15 +64,60 @@ export const DEMO_CAPABILITIES: DemoCapability[] = [
   },
 ];
 
-export function getAgentTools() {
-  // Keep this empty until the actual capabilities are implemented.
-  // The UI and system prompt both surface these as unavailable so the demo
-  // stays honest while the backend structure remains ready for expansion.
-  return [];
-}
+export const GROUNDED_CAPABILITIES: DemoCapability[] = [
+  {
+    id: "streaming_text",
+    label: "Streaming responses",
+    enabled: true,
+    availability: "available",
+    description: "LangChain agent text streaming is live in this slice.",
+  },
+  {
+    id: "supplie_demo_tools",
+    label: "Supplie demo snapshot tools",
+    enabled: true,
+    availability: "available",
+    description:
+      "The grounded panel can query built-in Supplie demo data tools against a static snapshot bundled with this app.",
+  },
+  {
+    id: "live_systems",
+    label: "Live ERP / warehouse access",
+    enabled: false,
+    availability: "planned",
+    description:
+      "No live operational systems are connected. Grounded answers are limited to the bundled demo snapshot.",
+  },
+  {
+    id: "native_web_search",
+    label: "Native web search",
+    enabled: false,
+    availability: "planned",
+    description:
+      "Not wired yet. Add a real search tool before exposing browsing in the UI.",
+  },
+  {
+    id: "code_sandbox",
+    label: "Code sandbox",
+    enabled: false,
+    availability: "planned",
+    description:
+      "Not wired yet. Do not imply code execution until a real sandbox is connected.",
+  },
+  {
+    id: "file_access",
+    label: "Files",
+    enabled: false,
+    availability: "planned",
+    description:
+      "Not wired yet. Do not imply file reads or downloads until file tooling exists.",
+  },
+];
 
-export function getCapabilitySummaryLines(): string[] {
-  return DEMO_CAPABILITIES.map((capability) => {
+export function getCapabilitySummaryLines(
+  capabilities: DemoCapability[],
+): string[] {
+  return capabilities.map((capability) => {
     const status = capability.enabled ? "available" : "not available";
     return `- ${capability.label}: ${status}. ${capability.description}`;
   });

--- a/lib/server/demo-config.ts
+++ b/lib/server/demo-config.ts
@@ -1,0 +1,66 @@
+import type { DemoCapability } from "./demo-capabilities";
+import {
+  GROUNDED_CAPABILITIES,
+  UNGROUNDED_CAPABILITIES,
+} from "./demo-capabilities";
+
+export type DemoProvider = "openai" | "anthropic";
+export type DemoAgentMode = "ungrounded" | "grounded";
+export type DemoBadgeColor = "amber" | "teal";
+
+export interface DemoPanelConfig {
+  id: DemoAgentMode;
+  title: string;
+  badge: string;
+  badgeColor: DemoBadgeColor;
+  backendLabel: string;
+  description: string;
+  emptyStateTitle: string;
+  emptyStateDetail: string;
+  capabilities: DemoCapability[];
+}
+
+export const DEMO_PANEL_CONFIGS: Record<DemoAgentMode, DemoPanelConfig> = {
+  ungrounded: {
+    id: "ungrounded",
+    title: "Ungrounded / Raw Agent",
+    badge: "Reasoning only",
+    badgeColor: "amber",
+    backendLabel: "LangChain ungrounded agent",
+    description:
+      "Answers from general reasoning only. No grounded Supplie data tools are available on this side.",
+    emptyStateTitle: "Raw reasoning appears here",
+    emptyStateDetail:
+      "This panel stays ungrounded and should disclose when a question needs real data or tools.",
+    capabilities: UNGROUNDED_CAPABILITIES,
+  },
+  grounded: {
+    id: "grounded",
+    title: "Grounded Supplie Agent",
+    badge: "Supplie tools",
+    badgeColor: "teal",
+    backendLabel: "Supplie grounded demo agent",
+    description:
+      "Uses built-in Supplie demo tools against a static bundled snapshot. No live ERP, browsing, code execution, or file access.",
+    emptyStateTitle: "Grounded tool-backed answers appear here",
+    emptyStateDetail:
+      "This panel can query the bundled Supplie demo snapshot and should say when a question falls outside that data.",
+    capabilities: GROUNDED_CAPABILITIES,
+  },
+};
+
+export function getPublicDemoConfig() {
+  return {
+    comparisonMode: "dual-agent",
+    panels: [
+      DEMO_PANEL_CONFIGS.ungrounded,
+      DEMO_PANEL_CONFIGS.grounded,
+    ] satisfies DemoPanelConfig[],
+    sharedLimitations: [
+      "No live ERP or warehouse connectivity.",
+      "No native web search.",
+      "No code sandbox.",
+      "No file access or downloads.",
+    ],
+  };
+}

--- a/lib/server/grounded-agent.ts
+++ b/lib/server/grounded-agent.ts
@@ -1,0 +1,340 @@
+import { tool } from "@langchain/core/tools";
+import { createAgent } from "langchain";
+import { z } from "zod";
+import {
+  GROUNDED_CAPABILITIES,
+  getCapabilitySummaryLines,
+} from "./demo-capabilities";
+import type { DemoProvider } from "./demo-config";
+
+interface GroundedAgentOptions {
+  model: string;
+  provider: DemoProvider;
+}
+
+interface DemoOrderSnapshot {
+  order_id: string;
+  booked_at: string;
+  customer: string;
+  revenue: number;
+  cogs: number;
+  freight: number;
+  rebates: number;
+}
+
+interface DemoStockRisk {
+  sku: string;
+  description: string;
+  supplier: string;
+  on_hand_units: number;
+  forecast_30d_units: number;
+  days_remaining: number;
+  urgent: boolean;
+  recommended_action: string;
+}
+
+interface DemoSupplierLeakage {
+  supplier: string;
+  leakage_amount: number;
+  mean_margin_pct: number;
+  negative_margin_orders: number;
+  primary_driver: string;
+  supporting_detail: string;
+}
+
+const DEMO_SNAPSHOT = {
+  snapshot_id: "supplie-demo-snapshot-2026-03-22",
+  captured_at: "2026-03-22T18:00:00Z",
+  disclosure:
+    "This is a static Supplie demo snapshot bundled with the app. It is not live production data.",
+  orders: [
+    {
+      order_id: "SK-240317-01",
+      booked_at: "2026-03-17",
+      customer: "Suspension King",
+      revenue: 18420,
+      cogs: 11980,
+      freight: 920,
+      rebates: 460,
+    },
+    {
+      order_id: "SK-240319-02",
+      booked_at: "2026-03-19",
+      customer: "Suspension King",
+      revenue: 14280,
+      cogs: 10140,
+      freight: 1180,
+      rebates: 520,
+    },
+    {
+      order_id: "SK-240321-03",
+      booked_at: "2026-03-21",
+      customer: "Suspension King",
+      revenue: 11240,
+      cogs: 9360,
+      freight: 980,
+      rebates: 410,
+    },
+  ] satisfies DemoOrderSnapshot[],
+  stock_risks: [
+    {
+      sku: "COIL-PRADO-450",
+      description: "Prado 450 progressive rear coil",
+      supplier: "Atlas Springs",
+      on_hand_units: 18,
+      forecast_30d_units: 42,
+      days_remaining: 12,
+      urgent: true,
+      recommended_action: "Expedite PO 7712 and reserve stock for open backorders.",
+    },
+    {
+      sku: "UCA-RANGER-22",
+      description: "Ranger upper control arm kit",
+      supplier: "North Ridge Fabrication",
+      on_hand_units: 9,
+      forecast_30d_units: 21,
+      days_remaining: 14,
+      urgent: true,
+      recommended_action: "Pull forward the next supplier shipment by one week.",
+    },
+    {
+      sku: "SHOCK-HILUX-MT",
+      description: "Hilux monotube front shock",
+      supplier: "Motion Damping Co",
+      on_hand_units: 26,
+      forecast_30d_units: 39,
+      days_remaining: 20,
+      urgent: false,
+      recommended_action: "Top up current PO quantity before the reorder cut-off.",
+    },
+    {
+      sku: "BUSH-KIT-80S",
+      description: "LandCruiser 80 series bush kit",
+      supplier: "Rubberline",
+      on_hand_units: 31,
+      forecast_30d_units: 33,
+      days_remaining: 28,
+      urgent: false,
+      recommended_action: "Watch daily sell-through and stage a small replenishment.",
+    },
+  ] satisfies DemoStockRisk[],
+  supplier_leakage: [
+    {
+      supplier: "Atlas Springs",
+      leakage_amount: 11200,
+      mean_margin_pct: 11.8,
+      negative_margin_orders: 4,
+      primary_driver: "Freight variance on bulky coil lines",
+      supporting_detail:
+        "Expedited inbound freight and rebate slippage are compressing margin on high-volume lift-kit orders.",
+    },
+    {
+      supplier: "North Ridge Fabrication",
+      leakage_amount: 8400,
+      mean_margin_pct: 13.4,
+      negative_margin_orders: 2,
+      primary_driver: "Late cost updates",
+      supporting_detail:
+        "Quoted sell prices lagged revised supplier costs on premium Ranger kits.",
+    },
+    {
+      supplier: "Motion Damping Co",
+      leakage_amount: 5900,
+      mean_margin_pct: 15.1,
+      negative_margin_orders: 1,
+      primary_driver: "Rebate under-collection",
+      supporting_detail:
+        "Expected promo rebates were not fully accrued on bundled shock packages.",
+    },
+  ] satisfies DemoSupplierLeakage[],
+};
+
+const groundedTools = [
+  tool(
+    async () => ({
+      snapshot_id: DEMO_SNAPSHOT.snapshot_id,
+      captured_at: DEMO_SNAPSHOT.captured_at,
+      disclosure: DEMO_SNAPSHOT.disclosure,
+      supported_questions: [
+        "Suspension King net margin after freight and rebates for last week's orders",
+        "SKUs at risk of stockout over the next 30 days",
+        "Suppliers contributing the most margin leakage",
+      ],
+    }),
+    {
+      name: "get_supplie_demo_snapshot_context",
+      description:
+        "Use to confirm what the grounded Supplie demo snapshot contains and how it should be disclosed.",
+      schema: z.object({}),
+    },
+  ),
+  tool(
+    async ({
+      customer,
+      period,
+    }: {
+      customer?: string;
+      period?: "last_week" | "all_snapshot_orders";
+    }) => {
+      const normalizedCustomer = customer?.trim().toLowerCase();
+      const filteredOrders = DEMO_SNAPSHOT.orders.filter((order) => {
+        if (!normalizedCustomer) {
+          return true;
+        }
+
+        return order.customer.toLowerCase().includes(normalizedCustomer);
+      });
+
+      const revenue = filteredOrders.reduce((sum, order) => sum + order.revenue, 0);
+      const cogs = filteredOrders.reduce((sum, order) => sum + order.cogs, 0);
+      const freight = filteredOrders.reduce((sum, order) => sum + order.freight, 0);
+      const rebates = filteredOrders.reduce((sum, order) => sum + order.rebates, 0);
+      const net_margin = revenue - cogs - freight - rebates;
+      const margin_pct =
+        revenue > 0 ? Number(((net_margin / revenue) * 100).toFixed(1)) : 0;
+
+      return {
+        snapshot_id: DEMO_SNAPSHOT.snapshot_id,
+        disclosure: DEMO_SNAPSHOT.disclosure,
+        period: period ?? "last_week",
+        customer: customer ?? "All customers in snapshot",
+        total_orders: filteredOrders.length,
+        revenue,
+        cogs,
+        freight,
+        rebates,
+        net_margin,
+        margin_pct,
+        orders: filteredOrders.map((order) => ({
+          ...order,
+          net_margin:
+            order.revenue - order.cogs - order.freight - order.rebates,
+          margin_pct: Number(
+            (
+              ((order.revenue - order.cogs - order.freight - order.rebates) /
+                order.revenue) *
+              100
+            ).toFixed(1),
+          ),
+        })),
+      };
+    },
+    {
+      name: "query_order_margin_snapshot",
+      description:
+        "Look up grounded order margin data from the Supplie demo snapshot, including freight and rebate impacts.",
+      schema: z.object({
+        customer: z
+          .string()
+          .optional()
+          .describe("Customer name to filter by, for example Suspension King."),
+        period: z
+          .enum(["last_week", "all_snapshot_orders"])
+          .optional()
+          .describe("Time window in the static demo snapshot."),
+      }),
+    },
+  ),
+  tool(
+    async ({ horizon_days }: { horizon_days?: number }) => {
+      const horizon = horizon_days ?? 30;
+      const exceptions = DEMO_SNAPSHOT.stock_risks.filter(
+        (risk) => risk.days_remaining <= horizon,
+      );
+
+      return {
+        snapshot_id: DEMO_SNAPSHOT.snapshot_id,
+        disclosure: DEMO_SNAPSHOT.disclosure,
+        horizon_days: horizon,
+        exception_count: exceptions.length,
+        urgent_count: exceptions.filter((risk) => risk.urgent).length,
+        skus: exceptions,
+      };
+    },
+    {
+      name: "query_stockout_risk_snapshot",
+      description:
+        "Return grounded SKU stockout risks from the Supplie demo snapshot for the requested planning horizon.",
+      schema: z.object({
+        horizon_days: z
+          .number()
+          .int()
+          .min(1)
+          .max(90)
+          .optional()
+          .describe("Planning horizon in days. Default is 30."),
+      }),
+    },
+  ),
+  tool(
+    async ({ top_n }: { top_n?: number }) => {
+      const topN = Math.max(1, Math.min(top_n ?? 3, 5));
+      const ranked = [...DEMO_SNAPSHOT.supplier_leakage]
+        .sort((left, right) => right.leakage_amount - left.leakage_amount)
+        .slice(0, topN);
+      const top = ranked[0];
+
+      return {
+        snapshot_id: DEMO_SNAPSHOT.snapshot_id,
+        disclosure: DEMO_SNAPSHOT.disclosure,
+        supplier_count: ranked.length,
+        supplier: top?.supplier ?? null,
+        leakage_amount: top?.leakage_amount ?? 0,
+        mean_margin_pct: top?.mean_margin_pct ?? 0,
+        negative_margin_orders: top?.negative_margin_orders ?? 0,
+        suppliers: ranked,
+      };
+    },
+    {
+      name: "query_supplier_margin_leakage_snapshot",
+      description:
+        "Rank suppliers by margin leakage using the grounded Supplie demo snapshot.",
+      schema: z.object({
+        top_n: z
+          .number()
+          .int()
+          .min(1)
+          .max(5)
+          .optional()
+          .describe("How many suppliers to rank. Default is 3."),
+      }),
+    },
+  ),
+];
+
+const agentCache = new Map<string, ReturnType<typeof createAgent>>();
+
+function buildModelRef({ model, provider }: GroundedAgentOptions): string {
+  return `${provider}:${model}`;
+}
+
+function buildSystemPrompt(): string {
+  return [
+    "You are the grounded Supplie demo agent for a supply-chain comparison demo.",
+    "Always use the supplied Supplie demo tools before answering any question that asks for numbers, rankings, order details, stock risk, or supplier leakage.",
+    "Your grounded data is limited to the bundled Supplie demo snapshot. It is not live production data.",
+    "Never claim to have accessed the web, code execution, files, or live ERP / warehouse systems unless a real tool in this run did that. Those capabilities are not available here.",
+    "If the user asks for something outside the bundled snapshot, say what is missing and keep the limitation explicit.",
+    "When you answer from the grounded snapshot, mention that it came from the Supplie demo snapshot.",
+    "",
+    "Current runtime capability status:",
+    ...getCapabilitySummaryLines(GROUNDED_CAPABILITIES),
+  ].join("\n");
+}
+
+export function getGroundedAgent(options: GroundedAgentOptions) {
+  const cacheKey = `${options.provider}:${options.model}`;
+  const cached = agentCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const agent = createAgent({
+    model: buildModelRef(options),
+    tools: groundedTools,
+    systemPrompt: buildSystemPrompt(),
+  });
+
+  agentCache.set(cacheKey, agent);
+  return agent;
+}

--- a/lib/server/ungrounded-agent.ts
+++ b/lib/server/ungrounded-agent.ts
@@ -1,7 +1,9 @@
 import { createAgent } from "langchain";
-import { DEMO_CAPABILITIES, getAgentTools, getCapabilitySummaryLines } from "./demo-capabilities";
-
-export type DemoProvider = "openai" | "anthropic";
+import {
+  UNGROUNDED_CAPABILITIES,
+  getCapabilitySummaryLines,
+} from "./demo-capabilities";
+import type { DemoProvider } from "./demo-config";
 
 interface UngroundedAgentOptions {
   model: string;
@@ -23,7 +25,7 @@ function buildSystemPrompt(): string {
     "Keep answers direct and useful, but be explicit about capability limits.",
     "",
     "Current runtime capability status:",
-    ...getCapabilitySummaryLines(),
+    ...getCapabilitySummaryLines(UNGROUNDED_CAPABILITIES),
   ].join("\n");
 }
 
@@ -50,19 +52,10 @@ export function getUngroundedAgent(options: UngroundedAgentOptions) {
 
   const agent = createAgent({
     model: buildModelRef(options),
-    tools: getAgentTools(),
+    tools: [],
     systemPrompt: buildSystemPrompt(),
   });
 
   agentCache.set(cacheKey, agent);
   return agent;
-}
-
-export function getPublicDemoConfig() {
-  return {
-    backendId: "langchain-ungrounded-agent",
-    backendLabel: "LangChain ungrounded agent",
-    sharedAcrossPanels: true,
-    capabilities: DEMO_CAPABILITIES,
-  };
 }


### PR DESCRIPTION
## Summary
- split the demo into distinct raw and grounded panels with separate backend behavior
- add grounded Supplie demo tools backed by a static bundled snapshot while keeping truthful capability limits explicit
- update the UI and public config/docs to reflect the real two-agent comparison

## Testing
- npm run typecheck
- npm run lint
- DEMO_PASSWORD=test_password OPENAI_API_KEY=test-openai-key ANTHROPIC_API_KEY=test-anthropic-key npm run build
- curl -s http://127.0.0.1:3010/api/config (after local start smoke test)

Closes #7