### PR TITLE
Fix #10: restore the live demo chat flow

### DIFF
--- a/lib/server/chat-model.test.ts
+++ b/lib/server/chat-model.test.ts
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ChatAnthropic } from "@langchain/anthropic";
+import { ChatOpenAI } from "@langchain/openai";
+// Node's built-in test runner needs the explicit .ts suffix here.
+// @ts-expect-error TypeScript does not allow TS extensions without allowImportingTsExtensions.
+import { getChatModel } from "./chat-model.ts";
+
+test("getChatModel returns a concrete OpenAI chat model instance", () => {
+  process.env.OPENAI_API_KEY = "test-openai-key";
+
+  const chatModel = getChatModel({
+    model: "gpt-5.4-mini-2026-03-17",
+    provider: "openai",
+  });
+
+  assert.ok(chatModel instanceof ChatOpenAI);
+});
+
+test("getChatModel returns a concrete Anthropic chat model instance", () => {
+  process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+
+  const chatModel = getChatModel({
+    model: "claude-sonnet-4-5",
+    provider: "anthropic",
+  });
+
+  assert.ok(chatModel instanceof ChatAnthropic);
+});
+
+test("getChatModel caches provider/model instances", () => {
+  process.env.OPENAI_API_KEY = "test-openai-key";
+
+  const first = getChatModel({
+    model: "gpt-5.4-mini-2026-03-17",
+    provider: "openai",
+  });
+  const second = getChatModel({
+    model: "gpt-5.4-mini-2026-03-17",
+    provider: "openai",
+  });
+
+  assert.equal(first, second);
+});

--- a/lib/server/chat-model.ts
+++ b/lib/server/chat-model.ts
@@ -1,0 +1,32 @@
+import { ChatAnthropic } from "@langchain/anthropic";
+import { ChatOpenAI } from "@langchain/openai";
+import type { DemoProvider } from "./demo-config";
+
+interface ChatModelOptions {
+  model: string;
+  provider: DemoProvider;
+}
+
+const chatModelCache = new Map<string, ChatOpenAI | ChatAnthropic>();
+
+export function getChatModel({ model, provider }: ChatModelOptions) {
+  const cacheKey = `${provider}:${model}`;
+  const cached = chatModelCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const chatModel =
+    provider === "anthropic"
+      ? new ChatAnthropic({
+          apiKey: process.env.ANTHROPIC_API_KEY,
+          model,
+        })
+      : new ChatOpenAI({
+          apiKey: process.env.OPENAI_API_KEY,
+          model,
+        });
+
+  chatModelCache.set(cacheKey, chatModel);
+  return chatModel;
+}

--- a/lib/server/grounded-agent.ts
+++ b/lib/server/grounded-agent.ts
@@ -6,6 +6,7 @@ import {
   getCapabilitySummaryLines,
 } from "./demo-capabilities";
 import type { DemoProvider } from "./demo-config";
+import { getChatModel } from "./chat-model";
 
 interface GroundedAgentOptions {
   model: string;
@@ -304,10 +305,6 @@ const groundedTools = [
 
 const agentCache = new Map<string, ReturnType<typeof createAgent>>();
 
-function buildModelRef({ model, provider }: GroundedAgentOptions): string {
-  return `${provider}:${model}`;
-}
-
 function buildSystemPrompt(): string {
   return [
     "You are the grounded Supplie demo agent for a supply-chain comparison demo.",
@@ -330,7 +327,7 @@ export function getGroundedAgent(options: GroundedAgentOptions) {
   }
 
   const agent = createAgent({
-    model: buildModelRef(options),
+    model: getChatModel(options),
     tools: groundedTools,
     systemPrompt: buildSystemPrompt(),
   });

--- a/lib/server/ungrounded-agent.ts
+++ b/lib/server/ungrounded-agent.ts
@@ -4,6 +4,7 @@ import {
   getCapabilitySummaryLines,
 } from "./demo-capabilities";
 import type { DemoProvider } from "./demo-config";
+import { getChatModel } from "./chat-model";
 
 interface UngroundedAgentOptions {
   model: string;
@@ -11,10 +12,6 @@ interface UngroundedAgentOptions {
 }
 
 const agentCache = new Map<string, ReturnType<typeof createAgent>>();
-
-function buildModelRef({ model, provider }: UngroundedAgentOptions): string {
-  return `${provider}:${model}`;
-}
 
 function buildSystemPrompt(): string {
   return [
@@ -51,7 +48,7 @@ export function getUngroundedAgent(options: UngroundedAgentOptions) {
   }
 
   const agent = createAgent({
-    model: buildModelRef(options),
+    model: getChatModel(options),
     tools: [],
     systemPrompt: buildSystemPrompt(),
   });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test --experimental-strip-types"
   },
   "dependencies": {
     "@langchain/anthropic": "^1.3.25",


### PR DESCRIPTION
## Summary
- replace LangChain string model refs with concrete provider chat model instances so Next/Turbopack does not hit the dynamic import runtime error
- reuse the concrete model factory from both grounded and ungrounded agents
- add a focused regression test covering the provider-specific model factory contract

## Reproduction
- reproduced the break locally with the real app: `/api/chat` returned `3:"Cannot find module as expression is too dynamic"`
- confirmed the same break at the UI layer with real browser automation after wiring Playwright locally

## Validation
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- headless Playwright flow against `http://localhost:3001` with auth + prompt click, asserting the grounded panel renders `7,990` and the runtime error text is absent

Closes #10
