### PR TITLE
Fix #11: add Playwright functional testing to CI/CD pipeline

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -46,10 +46,49 @@ jobs:
           OPENAI_API_KEY: test-openai-key
           ANTHROPIC_API_KEY: test-anthropic-key
 
+  e2e:
+    name: Functional E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ github.run_id }}-${{ github.run_attempt }}
+          path: playwright-report
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results-${{ github.run_id }}-${{ github.run_attempt }}
+          path: test-results
+          if-no-files-found: ignore
+          retention-days: 14
+
   deploy-eks-dev:
     name: Deploy to EKS Dev
     runs-on: ubuntu-latest
-    needs: verify
+    needs: [verify, e2e]
     if: github.event_name != 'pull_request'
     environment: development
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # next.js
 /.next/

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -3,6 +3,10 @@ import { NextResponse } from "next/server";
 import { checkRateLimit } from "@/lib/server/rate-limit";
 import { getGroundedAgent } from "@/lib/server/grounded-agent";
 import {
+  createPlaywrightMockChatResponse,
+  isPlaywrightTestMode,
+} from "@/lib/server/playwright-mock-chat";
+import {
   encodeDone,
   encodeError,
   encodeMetadata,
@@ -115,6 +119,13 @@ export async function POST(req: Request) {
       { error: "A prompt is required." },
       { status: 400 },
     );
+  }
+
+  if (isPlaywrightTestMode()) {
+    return createPlaywrightMockChatResponse({
+      agentMode,
+      prompt: messages.at(-1)?.content ?? body.prompt ?? "",
+    });
   }
 
   try {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -278,6 +278,7 @@ export default function Home() {
 
   return (
     <div
+      data-testid="demo-app"
       className="flex flex-col h-screen"
       style={{
         background: "var(--bg-primary)",
@@ -344,6 +345,7 @@ export default function Home() {
       <div className="flex flex-1 overflow-hidden">
         <div className="w-1/2">
           <Panel
+            panelId="ungrounded"
             title={ungroundedPanel.title}
             badge={ungroundedPanel.badge}
             badgeColor={ungroundedPanel.badgeColor}
@@ -360,6 +362,7 @@ export default function Home() {
         </div>
         <div className="w-1/2">
           <Panel
+            panelId="grounded"
             title={groundedPanel.title}
             badge={groundedPanel.badge}
             badgeColor={groundedPanel.badgeColor}

--- a/components/Panel.tsx
+++ b/components/Panel.tsx
@@ -5,6 +5,7 @@ import type { ChatMessage } from "@/hooks/useStreamingChat";
 import { ToolCallCard } from "./ToolCallCard";
 
 interface PanelProps {
+  panelId: "ungrounded" | "grounded";
   title: string;
   badge: string;
   badgeColor: "amber" | "teal";
@@ -20,6 +21,7 @@ interface PanelProps {
 }
 
 export function Panel({
+  panelId,
   title,
   badge,
   badgeColor,
@@ -51,6 +53,7 @@ export function Panel({
 
   return (
     <div
+      data-testid={`panel-${panelId}`}
       className={`flex flex-col h-full border-r ${borderColor} overflow-hidden`}
       style={{ background: bgColor }}
     >

--- a/components/PasswordGate.tsx
+++ b/components/PasswordGate.tsx
@@ -47,6 +47,7 @@ export function PasswordGate({ onAuth }: PasswordGateProps) {
 
   return (
     <div
+      data-testid="password-gate"
       className="fixed inset-0 z-50 flex flex-col items-center justify-center"
       style={{ background: "#0a0a0f" }}
     >
@@ -67,6 +68,7 @@ export function PasswordGate({ onAuth }: PasswordGateProps) {
           className={`w-full space-y-3 ${shake ? "animate-shake" : ""}`}
         >
           <input
+            data-testid="password-input"
             ref={inputRef}
             type="password"
             value={password}
@@ -76,6 +78,7 @@ export function PasswordGate({ onAuth }: PasswordGateProps) {
             autoComplete="current-password"
           />
           <button
+            data-testid="password-submit"
             type="submit"
             disabled={loading || !password.trim()}
             className="w-full bg-teal-600/80 hover:bg-teal-500/80 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm sm:text-base font-medium rounded-xl py-3.5 sm:py-3 transition-colors"
@@ -83,7 +86,10 @@ export function PasswordGate({ onAuth }: PasswordGateProps) {
             {loading ? "Checking…" : "Enter"}
           </button>
           {error && (
-            <div className="text-red-400 text-xs sm:text-sm text-center mt-2">
+            <div
+              data-testid="password-error"
+              className="text-red-400 text-xs sm:text-sm text-center mt-2"
+            >
               {error}
             </div>
           )}

--- a/lib/server/playwright-mock-chat.ts
+++ b/lib/server/playwright-mock-chat.ts
@@ -1,0 +1,83 @@
+import type { DemoAgentMode } from "./demo-config";
+import {
+  encodeDone,
+  encodeMetadata,
+  encodeTextDelta,
+} from "./stream-protocol";
+
+interface PlaywrightMockChatResponseOptions {
+  agentMode: DemoAgentMode;
+  prompt: string;
+}
+
+function chunkText(value: string, size: number) {
+  const chunks: string[] = [];
+
+  for (let index = 0; index < value.length; index += size) {
+    chunks.push(value.slice(index, index + size));
+  }
+
+  return chunks;
+}
+
+export function isPlaywrightTestMode() {
+  return process.env.PLAYWRIGHT_TEST_MODE === "1";
+}
+
+export function createPlaywrightMockChatResponse({
+  agentMode,
+  prompt,
+}: PlaywrightMockChatResponseOptions) {
+  const normalizedPrompt = prompt.trim() || "No prompt provided.";
+  const responseText =
+    agentMode === "grounded"
+      ? `Grounded mock response: the Supplie snapshot points to Suspension King as the main source of margin leakage for "${normalizedPrompt}".`
+      : `Ungrounded mock response: without grounded data I can only hypothesize about "${normalizedPrompt}" based on general reasoning.`;
+
+  const stream = new ReadableStream({
+    start(controller) {
+      if (agentMode === "grounded") {
+        controller.enqueue(
+          encodeMetadata({
+            type: "tool-start",
+            toolCallId: "playwright-grounded-lookup",
+            toolName: "query_supplie_snapshot",
+            args: {
+              question: normalizedPrompt,
+              dataset: "static-demo-snapshot",
+            },
+          }),
+        );
+      }
+
+      for (const chunk of chunkText(responseText, 28)) {
+        controller.enqueue(encodeTextDelta(chunk));
+      }
+
+      if (agentMode === "grounded") {
+        controller.enqueue(
+          encodeMetadata({
+            type: "tool-end",
+            toolCallId: "playwright-grounded-lookup",
+            toolName: "query_supplie_snapshot",
+            result: {
+              supplier: "Suspension King",
+              finding: "margin_leakage_rank_1",
+            },
+          }),
+        );
+      }
+
+      controller.enqueue(encodeDone());
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      "X-Vercel-AI-Data-Stream": "v1",
+    },
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -1525,6 +1526,22 @@
       "peer": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -3983,6 +4000,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5905,6 +5937,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test": "node --test --experimental-strip-types"
+    "test": "node --test --experimental-strip-types",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@langchain/anthropic": "^1.3.25",
@@ -22,7 +23,9 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
+    "@playwright/test": "^1.55.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = 3100;
+const host = "localhost";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  timeout: 45_000,
+  reporter: [
+    ["list"],
+    ["html", { open: "never", outputFolder: "playwright-report" }],
+  ],
+  use: {
+    baseURL: `http://${host}:${port}`,
+    testIdAttribute: "data-testid",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  webServer: {
+    command: process.env.CI
+      ? `npm run build && npm run start -- --hostname ${host} --port ${port}`
+      : `npm run dev -- --hostname ${host} --port ${port}`,
+    url: `http://${host}:${port}`,
+    reuseExistingServer: false,
+    timeout: 180_000,
+    env: {
+      DEMO_PASSWORD: "test_password",
+      PLAYWRIGHT_TEST_MODE: "1",
+    },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
+  ],
+});

--- a/tests/e2e/demo-flow.spec.ts
+++ b/tests/e2e/demo-flow.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const DEMO_PASSWORD = "test_password";
+const CRITICAL_PROMPT =
+  "Which supplier is causing the most margin leakage?";
+
+async function authenticate(page: Page, password = DEMO_PASSWORD) {
+  await page.goto("/");
+  await expect(page.getByTestId("password-gate")).toBeVisible();
+  await page.getByTestId("password-input").fill(password);
+  await page.getByTestId("password-submit").click();
+  await expect(page.getByTestId("demo-app")).toBeVisible();
+}
+
+test("requires the password gate before the demo is shown", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByTestId("password-gate")).toBeVisible();
+  await expect(page.getByTestId("demo-app")).toHaveCount(0);
+
+  await page.getByTestId("password-input").fill("wrong-password");
+  await page.getByTestId("password-submit").click();
+  await expect(page.getByTestId("password-error")).toHaveText(
+    "Incorrect password",
+  );
+
+  await page.getByTestId("password-input").fill(DEMO_PASSWORD);
+  await page.getByTestId("password-submit").click();
+
+  await expect(page.getByTestId("demo-app")).toBeVisible();
+  await expect(page.getByTestId("panel-ungrounded")).toContainText(
+    "Raw reasoning appears here",
+  );
+  await expect(page.getByTestId("panel-grounded")).toContainText(
+    "Grounded tool-backed answers appear here",
+  );
+});
+
+test("submits a prompt and renders streamed responses in both comparison panels", async ({
+  page,
+}) => {
+  await authenticate(page);
+
+  const ungroundedPanel = page.getByTestId("panel-ungrounded");
+  const groundedPanel = page.getByTestId("panel-grounded");
+
+  await page.getByRole("button", { name: CRITICAL_PROMPT }).click();
+
+  await expect(ungroundedPanel).toContainText(CRITICAL_PROMPT);
+  await expect(groundedPanel).toContainText(CRITICAL_PROMPT);
+  await expect(ungroundedPanel).toContainText("Ungrounded mock response:");
+  await expect(groundedPanel).toContainText("Grounded mock response:");
+  await expect(groundedPanel).toContainText("query_supplie_snapshot");
+  await expect(groundedPanel).toContainText("Suspension King");
+});


### PR DESCRIPTION
## Summary
- add Playwright configuration and functional coverage for the critical gated demo flow
- add a deterministic test-mode chat stream so CI can validate both panels without live model dependencies
- add a blocking e2e job to dev CI with retained Playwright report, traces, screenshots, and videos

## Testing
- npm run lint
- npm run typecheck
- npm run build
- npm run test:e2e

Closes #11