### PR TITLE
Fix #12: add GPT-5.4 screenshot critique gate to CI/CD

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -67,6 +67,15 @@ jobs:
       - name: Run Playwright tests
         run: npm run test:e2e
 
+      - name: Upload visual review inputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-review-inputs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/visual-review-inputs
+          if-no-files-found: error
+          retention-days: 14
+
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v4
@@ -85,10 +94,49 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  visual-review:
+    name: GPT-5.4 Visual Review
+    runs-on: ubuntu-latest
+    needs: e2e
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download visual review inputs
+        uses: actions/download-artifact@v4
+        with:
+          name: visual-review-inputs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/visual-review-inputs
+
+      - name: Run GPT-5.4 visual review gate
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          VISUAL_REVIEW_INPUT_DIR: artifacts/visual-review-inputs
+          VISUAL_REVIEW_OUTPUT_DIR: artifacts/visual-review-output
+          VISUAL_REVIEW_MODEL: gpt-5.4
+        run: npm run visual:review
+
+      - name: Upload visual review outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-review-output-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/visual-review-output
+          if-no-files-found: error
+          retention-days: 14
+
   deploy-eks-dev:
     name: Deploy to EKS Dev
     runs-on: ubuntu-latest
-    needs: [verify, e2e]
+    needs: [verify, e2e, visual-review]
     if: github.event_name != 'pull_request'
     environment: development
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /coverage
 /playwright-report
 /test-results
+/artifacts
 
 # next.js
 /.next/

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 /* ── Color system ─────────────────────────────────────── */
 :root {

--- a/docs/site-prd-demo-plan.md
+++ b/docs/site-prd-demo-plan.md
@@ -1,0 +1,70 @@
+# Supplie Demo Site PRD / Visual Review Rubric
+
+This document is the CI visual-review rubric for the current Supplie demo slice.
+It consolidates the accepted product intent from issues `#7`, `#11`, and `#12`
+into a deterministic checklist that GPT-5.4 can evaluate against screenshots.
+
+## Product Intent
+
+- The demo must present a trustworthy side-by-side comparison between two agents.
+- The left panel is the ungrounded / raw agent and must stay reasoning-only.
+- The right panel is the grounded Supplie agent and must show Supplie snapshot
+  tooling behavior.
+- The UI must disclose capabilities and limitations truthfully instead of
+  implying unavailable features.
+- A password gate must block the demo until the user authenticates.
+
+## Required Review States
+
+### 1. Locked Entry
+
+- The password gate fills the viewport.
+- The Supplie wordmark and `Grounding Demo` subtitle are visible.
+- A centered password input and primary `Enter` button are visible.
+- The protected comparison UI is not visible behind the gate.
+
+### 2. Authenticated Comparison
+
+- The top bar shows `Supplie.ai`, `Grounding Demo`, the model picker, and the
+  clear button.
+- Prompt chips are visible beneath the top bar.
+- A `Live Comparison` explainer is visible.
+- Two equal-width panels are visible side by side on desktop.
+- The left panel title is `Ungrounded / Raw Agent`.
+- The right panel title is `Grounded Supplie Agent`.
+- Amber styling is used for the raw side and teal styling is used for the
+  grounded side.
+- Empty states are readable and visually balanced.
+
+### 3. Post-Prompt Response
+
+- The same user prompt appears in both panels.
+- The left panel response is visibly framed as ungrounded reasoning.
+- The right panel response is visibly framed as grounded Supplie output.
+- The grounded panel includes tool evidence for the Supplie snapshot lookup.
+- The grounded result references the snapshot finding for `Suspension King`.
+
+## Visual Acceptance Criteria
+
+- `password_gate_integrity`: the gate looks intentional, centered, and protects
+  the demo content.
+- `comparison_layout`: the desktop layout clearly communicates a left-vs-right
+  comparison without clipped, overlapping, or collapsed regions.
+- `truthful_disclosure`: labels, explainer copy, and panel notes do not
+  overclaim live ERP, browsing, file access, or other missing capabilities.
+- `grounded_evidence_visibility`: the grounded panel makes its tool-backed
+  evidence visually distinct from the raw panel.
+- `readability_and_polish`: text is readable, contrast is acceptable, spacing is
+  coherent, and the screen does not look broken or unfinished.
+
+## Automatic Failure Conditions
+
+- A required state is missing or visually broken.
+- Either panel is missing, mislabeled, or no longer clearly side by side on the
+  desktop capture.
+- The password gate exposes protected content before authentication.
+- The grounded panel does not visually distinguish grounded evidence from the
+  raw panel.
+- Text is clipped, overlapping, or unreadable in any captured state.
+- The screenshots show obvious loading failure, blank output, or severe visual
+  regression.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.1",
+        "openai": "^6.33.0",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -1788,6 +1789,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
@@ -5740,9 +5805,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.32.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.32.0.tgz",
-      "integrity": "sha512-j3k+BjydAf8yQlcOI7WUQMQTbbF5GEIMAE2iZYCOzwwB3S2pCheaWYp+XZRNAch4jWVc52PMDGRRjutao3lLCg==",
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.33.0.tgz",
+      "integrity": "sha512-xAYN1W3YsDXJWA5F277135YfkEk6H7D3D6vWwRhJ3OEkzRgcyK8z/P5P9Gyi/wB4N8kK9kM5ZjprfvyHagKmpw==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "node --test --experimental-strip-types",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "visual:review": "node scripts/run-visual-review.mjs",
+    "visual:review:mock": "VISUAL_REVIEW_MOCK=1 node scripts/run-visual-review.mjs"
   },
   "dependencies": {
     "@langchain/anthropic": "^1.3.25",
@@ -25,12 +27,12 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
-    "@playwright/test": "^1.55.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.1",
+    "openai": "^6.33.0",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,12 +2,13 @@ import { defineConfig, devices } from "@playwright/test";
 
 const port = 3100;
 const host = "localhost";
+const useDevServer = process.env.PLAYWRIGHT_USE_DEV_SERVER === "1";
 
 export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: false,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: 1,
   timeout: 45_000,
   reporter: [
     ["list"],
@@ -21,9 +22,16 @@ export default defineConfig({
     video: "retain-on-failure",
   },
   webServer: {
-    command: process.env.CI
-      ? `npm run build && npm run start -- --hostname ${host} --port ${port}`
-      : `npm run dev -- --hostname ${host} --port ${port}`,
+    command: useDevServer
+      ? `npm run dev -- --hostname ${host} --port ${port}`
+      : [
+          "npm run build",
+          "rm -rf .next/standalone/.next/static .next/standalone/public",
+          "mkdir -p .next/standalone/.next",
+          "cp -R .next/static .next/standalone/.next/static",
+          "cp -R public .next/standalone/public",
+          `HOSTNAME=${host} PORT=${port} node .next/standalone/server.js`,
+        ].join(" && "),
     url: `http://${host}:${port}`,
     reuseExistingServer: false,
     timeout: 180_000,

--- a/scripts/run-visual-review.mjs
+++ b/scripts/run-visual-review.mjs
@@ -1,0 +1,509 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import OpenAI from "openai";
+
+const DEFAULT_MODEL = process.env.VISUAL_REVIEW_MODEL ?? "gpt-5.4";
+const INPUT_DIR = path.resolve(
+  process.env.VISUAL_REVIEW_INPUT_DIR ?? "artifacts/visual-review-inputs",
+);
+const OUTPUT_DIR = path.resolve(
+  process.env.VISUAL_REVIEW_OUTPUT_DIR ?? "artifacts/visual-review-output",
+);
+const RUBRIC_PATH = path.resolve(process.cwd(), "docs/site-prd-demo-plan.md");
+const MANIFEST_PATH = path.join(INPUT_DIR, "manifest.json");
+const REVIEW_JSON_PATH = path.join(OUTPUT_DIR, "visual-review.json");
+const GATE_JSON_PATH = path.join(OUTPUT_DIR, "gate-result.json");
+const SUMMARY_MD_PATH = path.join(OUTPUT_DIR, "summary.md");
+
+const REVIEW_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: [
+    "status",
+    "summary",
+    "score",
+    "criteria",
+    "screenshots",
+    "must_fix",
+    "strengths",
+  ],
+  properties: {
+    status: {
+      type: "string",
+      enum: ["pass", "fail"],
+    },
+    summary: {
+      type: "string",
+    },
+    score: {
+      type: "integer",
+      minimum: 0,
+      maximum: 100,
+    },
+    criteria: {
+      type: "array",
+      minItems: 5,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["id", "result", "evidence", "notes"],
+        properties: {
+          id: {
+            type: "string",
+            enum: [
+              "password_gate_integrity",
+              "comparison_layout",
+              "truthful_disclosure",
+              "grounded_evidence_visibility",
+              "readability_and_polish",
+            ],
+          },
+          result: {
+            type: "string",
+            enum: ["pass", "fail"],
+          },
+          evidence: {
+            type: "string",
+          },
+          notes: {
+            type: "string",
+          },
+        },
+      },
+    },
+    screenshots: {
+      type: "array",
+      minItems: 1,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["fileName", "state", "observations"],
+        properties: {
+          fileName: { type: "string" },
+          state: { type: "string" },
+          observations: { type: "string" },
+        },
+      },
+    },
+    must_fix: {
+      type: "array",
+      items: { type: "string" },
+    },
+    strengths: {
+      type: "array",
+      items: { type: "string" },
+    },
+  },
+};
+const REQUIRED_CRITERIA_IDS = new Set([
+  "password_gate_integrity",
+  "comparison_layout",
+  "truthful_disclosure",
+  "grounded_evidence_visibility",
+  "readability_and_polish",
+]);
+
+function dataUrlForImage(buffer, extension) {
+  const normalized = extension.toLowerCase();
+  const mimeType =
+    normalized === ".jpg" || normalized === ".jpeg"
+      ? "image/jpeg"
+      : normalized === ".webp"
+        ? "image/webp"
+        : normalized === ".gif"
+          ? "image/gif"
+          : "image/png";
+
+  return `data:${mimeType};base64,${buffer.toString("base64")}`;
+}
+
+function normalizeReviewResult(review) {
+  const criteria = Array.isArray(review?.criteria) ? review.criteria : [];
+  const missingCriteria = [...REQUIRED_CRITERIA_IDS].filter(
+    (criterionId) => !criteria.some((criterion) => criterion?.id === criterionId),
+  );
+  const failedCriteria = criteria.filter((criterion) => criterion.result !== "pass");
+  const mustFix = Array.isArray(review?.must_fix)
+    ? review.must_fix.filter((item) => typeof item === "string" && item.trim())
+    : [];
+  const status =
+    review?.status === "pass" &&
+    failedCriteria.length === 0 &&
+    mustFix.length === 0 &&
+    missingCriteria.length === 0
+      ? "pass"
+      : "fail";
+
+  return {
+    status,
+    summary:
+      typeof review?.summary === "string" && review.summary.trim()
+        ? review.summary.trim()
+        : "Visual review did not return a usable summary.",
+    score: Number.isInteger(review?.score) ? review.score : 0,
+    criteria,
+    screenshots: Array.isArray(review?.screenshots) ? review.screenshots : [],
+    must_fix: mustFix,
+    strengths: Array.isArray(review?.strengths)
+      ? review.strengths.filter(
+          (item) => typeof item === "string" && item.trim().length > 0,
+        )
+      : [],
+    failedCriteria: [
+      ...failedCriteria,
+      ...missingCriteria.map((criterionId) => ({
+        id: criterionId,
+        result: "fail",
+        evidence: "Model response omitted this required criterion.",
+        notes: "Gate failed closed because the structured review was incomplete.",
+      })),
+    ],
+  };
+}
+
+function renderSummary({ gate, model, manifest }) {
+  const criteriaLines = gate.criteria.map(
+    (criterion) =>
+      `- ${criterion.id}: ${criterion.result.toUpperCase()} | ${criterion.evidence}`,
+  );
+  const mustFixLines =
+    gate.must_fix.length > 0
+      ? gate.must_fix.map((item) => `- ${item}`)
+      : ["- None."];
+  const strengthLines =
+    gate.strengths.length > 0
+      ? gate.strengths.map((item) => `- ${item}`)
+      : ["- None recorded."];
+  const screenshotLines = manifest.screenshots.map(
+    (screenshot) => `- ${screenshot.fileName}: ${screenshot.description}`,
+  );
+
+  return [
+    "# GPT-5.4 Visual Review",
+    "",
+    `- Status: **${gate.status.toUpperCase()}**`,
+    `- Score: **${gate.score}/100**`,
+    `- Model: \`${model}\``,
+    `- Screenshots reviewed: **${manifest.screenshots.length}**`,
+    "",
+    "## Summary",
+    "",
+    gate.summary,
+    "",
+    "## Criteria",
+    "",
+    ...criteriaLines,
+    "",
+    "## Strengths",
+    "",
+    ...strengthLines,
+    "",
+    "## Required Fixes",
+    "",
+    ...mustFixLines,
+    "",
+    "## Screenshot Set",
+    "",
+    ...screenshotLines,
+    "",
+  ].join("\n");
+}
+
+async function loadInputs() {
+  const [rubricRaw, manifestRaw] = await Promise.all([
+    fs.readFile(RUBRIC_PATH, "utf8"),
+    fs.readFile(MANIFEST_PATH, "utf8"),
+  ]);
+  const manifest = JSON.parse(manifestRaw);
+
+  if (!Array.isArray(manifest?.screenshots) || manifest.screenshots.length === 0) {
+    throw new Error(`No screenshots were listed in ${MANIFEST_PATH}.`);
+  }
+
+  const screenshots = await Promise.all(
+    manifest.screenshots.map(async (screenshot) => {
+      const filePath = path.join(INPUT_DIR, screenshot.path);
+      const buffer = await fs.readFile(filePath);
+
+      return {
+        ...screenshot,
+        filePath,
+        dataUrl: dataUrlForImage(buffer, path.extname(filePath)),
+      };
+    }),
+  );
+
+  return {
+    rubricRaw,
+    manifest,
+    screenshots,
+  };
+}
+
+async function runMockReview({ manifest }) {
+  return {
+    status: "pass",
+    summary:
+      "Mock mode confirms the visual-review pipeline wiring and artifact generation path.",
+    score: 100,
+    criteria: [
+      {
+        id: "password_gate_integrity",
+        result: "pass",
+        evidence: "Password gate screenshot is present in the manifest.",
+        notes: "Mock mode only.",
+      },
+      {
+        id: "comparison_layout",
+        result: "pass",
+        evidence: "Authenticated comparison screenshot is present in the manifest.",
+        notes: "Mock mode only.",
+      },
+      {
+        id: "truthful_disclosure",
+        result: "pass",
+        evidence: "Post-auth comparison state was captured for review.",
+        notes: "Mock mode only.",
+      },
+      {
+        id: "grounded_evidence_visibility",
+        result: "pass",
+        evidence: "Post-prompt screenshot is present in the manifest.",
+        notes: "Mock mode only.",
+      },
+      {
+        id: "readability_and_polish",
+        result: "pass",
+        evidence: "All expected screenshots exist.",
+        notes: "Mock mode only.",
+      },
+    ],
+    screenshots: manifest.screenshots.map((screenshot) => ({
+      fileName: screenshot.fileName,
+      state: screenshot.state,
+      observations: "Mock review observed the expected screenshot artifact.",
+    })),
+    must_fix: [],
+    strengths: [
+      "Artifact generation, manifest writing, and summary rendering all completed.",
+    ],
+  };
+}
+
+async function runOpenAIReview({ rubricRaw, manifest, screenshots }) {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error(
+      "OPENAI_API_KEY is required for GPT-5.4 visual review. Set VISUAL_REVIEW_MOCK=1 to validate locally without an API call.",
+    );
+  }
+
+  const client = new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+  });
+
+  const userContent = [
+    {
+      type: "input_text",
+      text: [
+        "Review the supplied Supplie demo screenshots against the PRD/demo-plan rubric.",
+        "Fail the review if any required state or automatic failure condition is violated.",
+        "Base the answer only on what is visibly present in the screenshots and the supplied rubric.",
+        "",
+        "Rubric:",
+        rubricRaw,
+        "",
+        "Screenshot manifest:",
+        JSON.stringify(manifest, null, 2),
+      ].join("\n"),
+    },
+  ];
+
+  for (const screenshot of screenshots) {
+    userContent.push({
+      type: "input_text",
+      text: [
+        `Screenshot: ${screenshot.fileName}`,
+        `State: ${screenshot.state}`,
+        `Description: ${screenshot.description}`,
+      ].join("\n"),
+    });
+    userContent.push({
+      type: "input_image",
+      image_url: screenshot.dataUrl,
+    });
+  }
+
+  const response = await client.responses.create({
+    model: DEFAULT_MODEL,
+    store: false,
+    max_output_tokens: 2400,
+    text: {
+      format: {
+        type: "json_schema",
+        name: "supplie_visual_review",
+        schema: REVIEW_SCHEMA,
+        strict: true,
+      },
+    },
+    input: [
+      {
+        role: "developer",
+        content: [
+          {
+            type: "input_text",
+            text: [
+              "You are a strict CI visual gate reviewer.",
+              "Return pass only when every required state and acceptance criterion is satisfied.",
+              "If evidence is missing, ambiguous, visually broken, or contradicts the rubric, return fail.",
+              "Be concrete and reference the screenshot filenames in your reasoning.",
+            ].join(" "),
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: userContent,
+      },
+    ],
+  });
+
+  if (!response.output_text) {
+    throw new Error("OpenAI response did not include output_text.");
+  }
+
+  return {
+    parsed: JSON.parse(response.output_text),
+    responseId: response.id,
+  };
+}
+
+async function writeOutputs({ gate, manifest, rawReview, model }) {
+  await fs.mkdir(OUTPUT_DIR, { recursive: true });
+
+  const summary = renderSummary({ gate, model, manifest });
+  const gateResult = {
+    generatedAt: new Date().toISOString(),
+    model,
+    status: gate.status,
+    score: gate.score,
+    failedCriteria: gate.failedCriteria.map((criterion) => criterion.id),
+    reviewPath: path.relative(OUTPUT_DIR, REVIEW_JSON_PATH),
+    summaryPath: path.relative(OUTPUT_DIR, SUMMARY_MD_PATH),
+  };
+
+  await Promise.all([
+    fs.writeFile(
+      REVIEW_JSON_PATH,
+      `${JSON.stringify(rawReview, null, 2)}\n`,
+      "utf8",
+    ),
+    fs.writeFile(
+      GATE_JSON_PATH,
+      `${JSON.stringify(gateResult, null, 2)}\n`,
+      "utf8",
+    ),
+    fs.writeFile(SUMMARY_MD_PATH, summary, "utf8"),
+  ]);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await fs.appendFile(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`, "utf8");
+  }
+
+  console.log(summary);
+}
+
+async function writeFailureArtifacts(error) {
+  const failureReview = {
+    generatedAt: new Date().toISOString(),
+    model: DEFAULT_MODEL,
+    status: "fail",
+    summary: error.message,
+    criteria: [],
+    screenshots: [],
+    must_fix: [error.message],
+    strengths: [],
+  };
+  const gate = normalizeReviewResult(failureReview);
+
+  await fs.mkdir(OUTPUT_DIR, { recursive: true });
+  const summary = renderSummary({
+    gate,
+    model: DEFAULT_MODEL,
+    manifest: { screenshots: [] },
+  });
+
+  await Promise.all([
+    fs.writeFile(
+      REVIEW_JSON_PATH,
+      `${JSON.stringify(failureReview, null, 2)}\n`,
+      "utf8",
+    ),
+    fs.writeFile(
+      GATE_JSON_PATH,
+      `${JSON.stringify(
+        {
+          generatedAt: new Date().toISOString(),
+          model: DEFAULT_MODEL,
+          status: "fail",
+          score: 0,
+          failedCriteria: [],
+          error: error.message,
+          reviewPath: path.relative(OUTPUT_DIR, REVIEW_JSON_PATH),
+          summaryPath: path.relative(OUTPUT_DIR, SUMMARY_MD_PATH),
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    ),
+    fs.writeFile(SUMMARY_MD_PATH, summary, "utf8"),
+  ]);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await fs.appendFile(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`, "utf8");
+  }
+
+  console.error(summary);
+}
+
+async function main() {
+  try {
+    const inputs = await loadInputs();
+    const reviewResponse =
+      process.env.VISUAL_REVIEW_MOCK === "1"
+        ? { parsed: await runMockReview(inputs), responseId: "mock-review" }
+        : await runOpenAIReview(inputs);
+
+    const gate = normalizeReviewResult(reviewResponse.parsed);
+    const rawReview = {
+      generatedAt: new Date().toISOString(),
+      model: DEFAULT_MODEL,
+      responseId: reviewResponse.responseId,
+      review: reviewResponse.parsed,
+      gate: {
+        status: gate.status,
+        score: gate.score,
+        failedCriteria: gate.failedCriteria.map((criterion) => criterion.id),
+      },
+    };
+
+    await writeOutputs({
+      gate,
+      manifest: inputs.manifest,
+      rawReview,
+      model: DEFAULT_MODEL,
+    });
+
+    if (gate.status !== "pass") {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    const normalizedError =
+      error instanceof Error ? error : new Error(String(error));
+    await writeFailureArtifacts(normalizedError);
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/tests/e2e/visual-review.spec.ts
+++ b/tests/e2e/visual-review.spec.ts
@@ -1,0 +1,133 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, test, type Page } from "@playwright/test";
+
+const DEMO_PASSWORD = "test_password";
+const CRITICAL_PROMPT =
+  "Which supplier is causing the most margin leakage?";
+const OUTPUT_ROOT = path.join(
+  process.cwd(),
+  "artifacts",
+  "visual-review-inputs",
+);
+const SCREENSHOT_DIR = path.join(OUTPUT_ROOT, "screenshots");
+const MANIFEST_PATH = path.join(OUTPUT_ROOT, "manifest.json");
+
+interface VisualReviewScreenshot {
+  fileName: string;
+  path: string;
+  state: string;
+  description: string;
+  viewport: {
+    width: number;
+    height: number;
+  };
+}
+
+test.use({
+  viewport: { width: 1440, height: 1200 },
+});
+
+async function authenticate(page: Page, password = DEMO_PASSWORD) {
+  await page.goto("/");
+  await expect(page.getByTestId("password-gate")).toBeVisible();
+  await page.getByTestId("password-input").fill(password);
+  await page.getByTestId("password-submit").click();
+  await expect(page.getByTestId("demo-app")).toBeVisible();
+}
+
+async function captureScreenshot(
+  page: Page,
+  fileName: string,
+  state: string,
+  description: string,
+): Promise<VisualReviewScreenshot> {
+  const filePath = path.join(SCREENSHOT_DIR, fileName);
+  await page.screenshot({
+    path: filePath,
+    fullPage: true,
+    animations: "disabled",
+  });
+
+  return {
+    fileName,
+    path: path.posix.join("screenshots", fileName),
+    state,
+    description,
+    viewport: { width: 1440, height: 1200 },
+  };
+}
+
+test("captures deterministic screenshots for PRD-based visual review", async ({
+  page,
+}) => {
+  await fs.rm(OUTPUT_ROOT, { recursive: true, force: true });
+  await fs.mkdir(SCREENSHOT_DIR, { recursive: true });
+
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  const screenshots: VisualReviewScreenshot[] = [];
+
+  await page.goto("/");
+  await expect(page.getByTestId("password-gate")).toBeVisible();
+  screenshots.push(
+    await captureScreenshot(
+      page,
+      "01-password-gate.png",
+      "locked-entry",
+      "Password gate is visible before authentication and blocks access to the protected demo UI.",
+    ),
+  );
+
+  await authenticate(page);
+  await expect(page.getByText("Live Comparison")).toBeVisible();
+  await expect(page.getByTestId("panel-ungrounded")).toContainText(
+    "Raw reasoning appears here",
+  );
+  await expect(page.getByTestId("panel-grounded")).toContainText(
+    "Grounded tool-backed answers appear here",
+  );
+  screenshots.push(
+    await captureScreenshot(
+      page,
+      "02-authenticated-comparison.png",
+      "authenticated-comparison",
+      "Authenticated desktop comparison view with the top bar, prompt buttons, explainer, and both side-by-side panels in their empty states.",
+    ),
+  );
+
+  await page.getByRole("button", { name: CRITICAL_PROMPT }).click();
+  await expect(page.getByTestId("panel-ungrounded")).toContainText(
+    "Ungrounded mock response:",
+  );
+  await expect(page.getByTestId("panel-grounded")).toContainText(
+    "Grounded mock response:",
+  );
+  await expect(page.getByTestId("panel-grounded")).toContainText(
+    "query_supplie_snapshot",
+  );
+  await expect(page.getByTestId("panel-grounded")).toContainText(
+    "Suspension King",
+  );
+  screenshots.push(
+    await captureScreenshot(
+      page,
+      "03-post-prompt-grounded-response.png",
+      "post-prompt-response",
+      "Both panels show the same user prompt; the grounded panel also shows a Supplie snapshot tool call and the Suspension King finding.",
+    ),
+  );
+
+  await fs.writeFile(
+    MANIFEST_PATH,
+    `${JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        rubricPath: "docs/site-prd-demo-plan.md",
+        screenshots,
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+});


### PR DESCRIPTION
## Summary
- capture deterministic Playwright screenshots for the locked gate, authenticated comparison view, and post-prompt grounded response
- add a GPT-5.4 visual review step that scores those screenshots against a repo-local site PRD / demo-plan rubric and writes structured JSON + markdown artifacts
- wire CI so E2E artifacts are uploaded, the GPT review runs after E2E, artifacts are preserved, and deploy is blocked unless the visual gate passes

## Validation
- npx eslint app components hooks lib scripts tests playwright.config.ts
- npm run typecheck
- DEMO_PASSWORD=test_password OPENAI_API_KEY=test-openai-key ANTHROPIC_API_KEY=test-anthropic-key npm run build
- npm run test:e2e
- npm run visual:review:mock
- npm run visual:review

Closes #12