### PR TITLE
Fix #18: polish the demo comparison UI

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,21 +1,29 @@
 @import "tailwindcss";
 
-/* ── Color system ─────────────────────────────────────── */
 :root {
-  --bg-primary: #0f0f14;
-  --bg-secondary: #18181f;
-  --bg-amber-panel: #110f0a;
-  --bg-teal-panel: #0a0f12;
+  --bg-primary: #08121b;
+  --bg-shell: rgba(7, 12, 18, 0.84);
+  --bg-shell-strong: rgba(10, 16, 24, 0.96);
+  --bg-secondary: #101922;
+  --bg-tertiary: #172231;
+  --bg-amber-panel: linear-gradient(180deg, #1d1710 0%, #100d09 100%);
+  --bg-teal-panel: linear-gradient(180deg, #0f1d1f 0%, #081215 100%);
 
-  --text-primary: #f0f0f0;
-  --text-secondary: #a0a0a0;
-  --text-muted: #606070;
+  --text-primary: #f3f7fb;
+  --text-secondary: #b1bfd1;
+  --text-muted: #738298;
 
-  --accent-amber: #f59e0b;
-  --accent-teal: #14b8a6;
+  --border-subtle: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.14);
+  --shadow-panel: 0 24px 80px rgba(2, 6, 14, 0.42);
+
+  --accent-amber: #f3a63b;
+  --accent-amber-soft: rgba(243, 166, 59, 0.16);
+  --accent-teal: #2ed3c4;
+  --accent-teal-soft: rgba(46, 211, 196, 0.16);
+  --accent-sky: #72a8ff;
 }
 
-/* ── Animations ───────────────────────────────────────── */
 @keyframes slide-in {
   from {
     opacity: 0;
@@ -52,22 +60,64 @@
   }
 }
 
+@keyframes float {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(0, -14px, 0) scale(1.04);
+  }
+}
+
 .animate-slide-in {
   animation: slide-in 0.2s ease-out both;
 }
 .animate-shake {
   animation: shake 0.6s ease-in-out;
 }
+.animate-float-slow {
+  animation: float 12s ease-in-out infinite;
+}
+.animate-float-slower {
+  animation: float 16s ease-in-out infinite reverse;
+}
 
-/* ── Reset ────────────────────────────────────────────── */
 * {
   box-sizing: border-box;
 }
+
 html,
 body {
   height: 100%;
   margin: 0;
   padding: 0;
-  background: var(--bg-primary);
+  background:
+    radial-gradient(circle at top left, rgba(46, 211, 196, 0.12), transparent 28%),
+    radial-gradient(circle at top right, rgba(114, 168, 255, 0.18), transparent 26%),
+    linear-gradient(180deg, #061018 0%, #08111a 42%, #070c12 100%);
   color: var(--text-primary);
+  font-family: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
+}
+
+body::selection {
+  background: rgba(46, 211, 196, 0.3);
+}
+
+a {
+  color: inherit;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(115, 130, 152, 0.45);
+  border-radius: 999px;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -279,78 +279,89 @@ export default function Home() {
   return (
     <div
       data-testid="demo-app"
-      className="flex flex-col h-screen"
+      className="min-h-screen px-4 py-4 sm:px-5"
       style={{
-        background: "var(--bg-primary)",
-        fontFamily: "Inter, system-ui, sans-serif",
+        background: "transparent",
+        fontFamily: '"Space Grotesk", "Avenir Next", "Segoe UI", sans-serif',
       }}
     >
-      <div className="flex items-center gap-4 px-5 py-3 border-b border-white/5 flex-shrink-0">
-        <div className="flex items-center gap-2">
-          <div className="w-5 h-5 rounded bg-teal-500/20 flex items-center justify-center">
-            <div className="w-2 h-2 rounded-full bg-teal-400" />
+      <div className="mx-auto flex min-h-[calc(100vh-2rem)] w-full max-w-[1540px] flex-col rounded-[32px] border border-white/10 bg-[var(--bg-shell)] p-3 shadow-[0_32px_120px_rgba(2,6,14,0.5)] backdrop-blur-xl">
+        <div className="rounded-[28px] border border-white/8 bg-[linear-gradient(180deg,rgba(11,17,25,0.92),rgba(8,13,20,0.92))] px-5 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+          <div className="flex flex-wrap items-center gap-4">
+            <div className="flex min-w-0 items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-teal-300/20 bg-[linear-gradient(135deg,rgba(20,184,166,0.22),rgba(56,189,248,0.18))] shadow-[0_12px_30px_rgba(20,184,166,0.18)]">
+                <div className="h-3 w-3 rounded-full bg-teal-300" />
+              </div>
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span
+                    className="text-sm font-semibold"
+                    style={{ color: "var(--text-primary)" }}
+                  >
+                    Supplie.ai
+                  </span>
+                  <span
+                    className="text-[11px] uppercase tracking-[0.24em]"
+                    style={{ color: "var(--text-muted)" }}
+                  >
+                    Grounding Demo
+                  </span>
+                </div>
+                <div className="text-sm text-slate-400">
+                  Demo-quality side-by-side review of raw reasoning vs grounded
+                  Supplie output.
+                </div>
+              </div>
+            </div>
+            <div className="ml-auto flex items-center gap-3">
+              <ModelPicker value={model} onChange={handleModelChange} />
+              <button
+                onClick={handleClear}
+                className="rounded-xl border border-white/10 bg-[rgba(255,255,255,0.04)] px-3 py-2 text-xs text-slate-300 transition-all hover:border-white/20 hover:text-white"
+              >
+                Clear
+              </button>
+            </div>
           </div>
-          <span
-            className="text-sm font-semibold"
-            style={{ color: "var(--text-primary)" }}
-          >
-            Supplie.ai
-          </span>
-          <span className="text-sm" style={{ color: "var(--text-muted)" }}>
-            {"/" + "/"}
-          </span>
-          <span
-            className="text-xs uppercase tracking-wider"
-            style={{ color: "var(--text-secondary)" }}
-          >
-            Grounding Demo
-          </span>
-        </div>
-        <div className="ml-auto flex items-center gap-3">
-          <ModelPicker value={model} onChange={handleModelChange} />
-          <button
-            onClick={handleClear}
-            className="text-xs border border-slate-700/50 hover:border-slate-500/50 rounded-lg px-3 py-1.5 transition-all"
-            style={{ color: "var(--text-secondary)" }}
-          >
-            Clear
-          </button>
-        </div>
-      </div>
 
-      <PromptButtons
-        onPrompt={handlePrompt}
-        disabled={ungroundedChat.isLoading || groundedChat.isLoading}
-      />
+          <div className="mt-4 grid gap-3 xl:grid-cols-[1.25fr_0.9fr]">
+            <PromptButtons
+              onPrompt={handlePrompt}
+              disabled={ungroundedChat.isLoading || groundedChat.isLoading}
+            />
 
-      <div className="px-5 py-3 border-b border-white/5 bg-slate-950/30">
-        <div className="text-[11px] uppercase tracking-[0.18em] text-slate-500">
-          Live Comparison
+            <div className="rounded-[24px] border border-white/8 bg-[linear-gradient(180deg,rgba(9,14,22,0.86),rgba(9,13,20,0.74))] px-4 py-4">
+              <div className="text-[11px] uppercase tracking-[0.22em] text-slate-500">
+                Live Comparison
+              </div>
+              <div className="mt-2 text-sm leading-6 text-slate-100">
+                Left panel stays raw on {ungroundedPanel.backendLabel}. Right
+                panel runs {groundedPanel.backendLabel} with bundled Supplie
+                snapshot tools.
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2 text-xs">
+                <span className="rounded-full border border-[rgba(243,166,59,0.18)] bg-[rgba(243,166,59,0.08)] px-3 py-1 text-amber-200">
+                  Raw: {comparisonMessage.ungroundedCapabilities}
+                </span>
+                <span className="rounded-full border border-[rgba(46,211,196,0.18)] bg-[rgba(46,211,196,0.08)] px-3 py-1 text-teal-200">
+                  Grounded: {comparisonMessage.groundedCapabilities}
+                </span>
+              </div>
+              <div className="mt-3 text-xs leading-5 text-slate-400">
+                Shared limits: {comparisonMessage.sharedLimitations}
+              </div>
+            </div>
+          </div>
         </div>
-        <div className="mt-1 text-sm text-slate-200">
-          Left panel stays raw on {ungroundedPanel.backendLabel}. Right panel
-          runs {groundedPanel.backendLabel} with bundled Supplie snapshot tools.
-        </div>
-        <div className="mt-2 text-xs text-slate-400">
-          Raw panel: {comparisonMessage.ungroundedCapabilities}
-        </div>
-        <div className="mt-1 text-xs text-teal-300">
-          Grounded panel: {comparisonMessage.groundedCapabilities}
-        </div>
-        <div className="mt-1 text-xs text-slate-500">
-          Shared limits: {comparisonMessage.sharedLimitations}
-        </div>
-      </div>
 
-      <div className="flex flex-1 overflow-hidden">
-        <div className="w-1/2">
+        <div className="mt-3 grid min-h-0 flex-1 gap-3 lg:grid-cols-2">
           <Panel
             panelId="ungrounded"
             title={ungroundedPanel.title}
             badge={ungroundedPanel.badge}
             badgeColor={ungroundedPanel.badgeColor}
             bgColor="var(--bg-amber-panel)"
-            borderColor="border-amber-900/30"
+            borderColor="border-amber-300/14"
             note={ungroundedPanel.description}
             emptyStateTitle={ungroundedPanel.emptyStateTitle}
             emptyStateDetail={ungroundedPanel.emptyStateDetail}
@@ -359,15 +370,13 @@ export default function Home() {
             error={ungroundedChat.error}
             onRetry={handleRetryUngrounded}
           />
-        </div>
-        <div className="w-1/2">
           <Panel
             panelId="grounded"
             title={groundedPanel.title}
             badge={groundedPanel.badge}
             badgeColor={groundedPanel.badgeColor}
             bgColor="var(--bg-teal-panel)"
-            borderColor="border-teal-900/30"
+            borderColor="border-teal-300/14"
             note={groundedPanel.description}
             emptyStateTitle={groundedPanel.emptyStateTitle}
             emptyStateDetail={groundedPanel.emptyStateDetail}

--- a/components/ModelPicker.tsx
+++ b/components/ModelPicker.tsx
@@ -43,7 +43,9 @@ export function ModelPicker({ value, onChange }: ModelPickerProps) {
 
   return (
     <div className="flex items-center gap-2">
-      <span className="text-xs text-slate-500">Model:</span>
+      <span className="text-xs uppercase tracking-[0.2em] text-slate-500">
+        Model
+      </span>
       <div className="relative">
         <select
           value={value}
@@ -51,7 +53,7 @@ export function ModelPicker({ value, onChange }: ModelPickerProps) {
             const m = MODELS.find((m) => m.modelId === e.target.value)!;
             onChange(m.modelId, m.provider);
           }}
-          className="text-xs bg-slate-800/60 text-slate-300 border border-slate-700/50 rounded-lg pl-3 pr-8 py-1.5 focus:outline-none focus:border-teal-600/50 cursor-pointer appearance-none"
+          className="cursor-pointer appearance-none rounded-xl border border-white/10 bg-[linear-gradient(180deg,rgba(20,29,42,0.9),rgba(10,15,24,0.9))] py-2 pl-3 pr-8 text-xs text-slate-200 outline-none transition-colors focus:border-teal-400/50"
         >
           {MODELS.map((m) => (
             <option key={m.modelId} value={m.modelId}>
@@ -64,7 +66,7 @@ export function ModelPicker({ value, onChange }: ModelPickerProps) {
         </select>
         <div className="pointer-events-none absolute inset-y-0 right-2 flex items-center">
           <svg
-            className="w-3 h-3 text-slate-500"
+            className="h-3 w-3 text-slate-500"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"

--- a/components/Panel.tsx
+++ b/components/Panel.tsx
@@ -47,57 +47,93 @@ export function Panel({
     error?.message?.includes("401") || error?.message?.includes("Unauthorized");
 
   const badgeStyles = {
-    amber: "bg-amber-900/40 text-amber-300 border border-amber-700/40",
-    teal: "bg-teal-900/40 text-teal-300 border border-teal-700/40",
+    amber:
+      "border border-[rgba(243,166,59,0.18)] bg-[rgba(243,166,59,0.12)] text-amber-200",
+    teal:
+      "border border-[rgba(46,211,196,0.18)] bg-[rgba(46,211,196,0.12)] text-teal-200",
   };
+  const accentStyles = {
+    amber: {
+      orb: "bg-amber-300/80",
+      ring: "border-[rgba(243,166,59,0.2)] bg-[rgba(243,166,59,0.06)]",
+      note: "from-amber-500/10 to-transparent",
+      message:
+        "border-[rgba(243,166,59,0.14)] bg-[rgba(243,166,59,0.08)]",
+      userMessage: "border-slate-600/50 bg-[linear-gradient(180deg,rgba(33,44,61,0.92),rgba(25,34,49,0.92))]",
+      retry:
+        "border-[rgba(243,166,59,0.3)] text-amber-200 hover:border-[rgba(243,166,59,0.6)]",
+    },
+    teal: {
+      orb: "bg-teal-300/80",
+      ring: "border-[rgba(46,211,196,0.2)] bg-[rgba(46,211,196,0.06)]",
+      note: "from-teal-400/10 to-transparent",
+      message:
+        "border-[rgba(46,211,196,0.14)] bg-[rgba(46,211,196,0.08)]",
+      userMessage: "border-slate-600/50 bg-[linear-gradient(180deg,rgba(33,44,61,0.92),rgba(25,34,49,0.92))]",
+      retry:
+        "border-[rgba(46,211,196,0.3)] text-teal-200 hover:border-[rgba(46,211,196,0.6)]",
+    },
+  };
+  const accent = accentStyles[badgeColor];
 
   return (
     <div
       data-testid={`panel-${panelId}`}
-      className={`flex flex-col h-full border-r ${borderColor} overflow-hidden`}
+      className={`flex h-full flex-col overflow-hidden rounded-[28px] border ${borderColor} shadow-[0_24px_60px_rgba(3,8,16,0.28)]`}
       style={{ background: bgColor }}
     >
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-white/5">
+      <div className="border-b border-white/8 px-5 py-4">
+        <div className="flex items-center gap-3">
+          <div className={`h-2.5 w-2.5 rounded-full ${accent.orb} shadow-lg`} />
+          <span
+            className="text-[15px] font-semibold tracking-[-0.02em]"
+            style={{ color: "var(--text-primary)" }}
+          >
+            {title}
+          </span>
+          <span
+            className={`rounded-full px-2.5 py-1 text-[11px] uppercase tracking-[0.18em] ${badgeStyles[badgeColor]}`}
+          >
+            {badge}
+          </span>
+          {isLoading && (
+            <div className="ml-auto flex gap-1.5">
+              {[0, 1, 2].map((i) => (
+                <div
+                  key={i}
+                  className={`h-1.5 w-1.5 rounded-full ${badgeColor === "teal" ? "bg-teal-300" : "bg-amber-300"} animate-bounce`}
+                  style={{ animationDelay: `${i * 150}ms` }}
+                />
+              ))}
+            </div>
+          )}
+        </div>
         <span
-          className="text-sm font-semibold"
-          style={{ color: "var(--text-primary)" }}
+          className={`mt-3 block rounded-2xl border border-white/8 bg-gradient-to-r px-4 py-3 text-xs leading-relaxed text-slate-300 ${accent.note}`}
         >
-          {title}
+          {note}
         </span>
-        <span
-          className={`text-xs uppercase tracking-wider px-2 py-0.5 rounded-full ${badgeStyles[badgeColor]}`}
-        >
-          {badge}
-        </span>
-        {isLoading && (
-          <div className="ml-auto flex gap-1">
-            {[0, 1, 2].map((i) => (
-              <div
-                key={i}
-                className={`w-1.5 h-1.5 rounded-full ${badgeColor === "teal" ? "bg-teal-400" : "bg-amber-400"} animate-bounce`}
-                style={{ animationDelay: `${i * 150}ms` }}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-      <div className="px-4 py-2 border-b border-white/5 bg-black/10">
-        <p className="text-xs leading-relaxed text-slate-400">{note}</p>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+      <div className="flex-1 space-y-4 overflow-y-auto p-5">
         {messages.length === 0 && !error && (
-          <div className="flex items-center justify-center h-full">
-            <div className="text-center">
+          <div className="flex h-full items-center justify-center">
+            <div
+              className={`max-w-sm rounded-[28px] border p-8 text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] ${accent.ring}`}
+            >
+              <div
+                className={`mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl border border-white/8 ${accent.message}`}
+              >
+                <div className={`h-3 w-3 rounded-full ${accent.orb}`} />
+              </div>
               <p
-                className="text-sm"
+                className="text-base font-medium"
                 style={{ color: "var(--text-secondary)" }}
               >
                 {emptyStateTitle}
               </p>
-              <br />
               <span
-                className="text-xs"
+                className="mt-3 block text-sm leading-6"
                 style={{ color: "var(--text-muted)" }}
               >
                 {emptyStateDetail}
@@ -110,13 +146,17 @@ export function Panel({
           <div key={msg.id} className="space-y-2">
             {msg.role === "user" && (
               <div className="flex justify-end">
-                <div className="bg-slate-800/60 text-slate-100 text-sm rounded-lg px-3 py-2 max-w-xs">
+                <div
+                  className={`max-w-xs rounded-2xl border px-4 py-3 text-sm text-slate-100 shadow-[0_12px_30px_rgba(3,8,16,0.22)] ${accent.userMessage}`}
+                >
                   {msg.content}
                 </div>
               </div>
             )}
             {msg.role === "assistant" && (
-              <div className="space-y-2">
+              <div
+                className={`space-y-3 rounded-[24px] border px-4 py-4 ${accent.message}`}
+              >
                 {msg.toolInvocations &&
                   msg.toolInvocations.filter(
                     (inv) => inv.toolName !== "__output_file__"
@@ -143,9 +183,9 @@ export function Panel({
                           );
                         })}
                     </div>
-                  )}
+                )}
                 {msg.content && (
-                  <div className="text-slate-100 text-sm leading-relaxed whitespace-pre-wrap">
+                  <div className="whitespace-pre-wrap text-sm leading-7 text-slate-100">
                     {msg.content}
                   </div>
                 )}
@@ -158,7 +198,7 @@ export function Panel({
           <div className="flex items-center gap-2">
             <button
               onClick={onRetry}
-              className="text-xs text-teal-400 border border-teal-800/50 hover:border-teal-600/50 rounded-full px-3 py-1 transition-colors"
+              className={`rounded-full border px-3 py-1 text-xs transition-colors ${accent.retry}`}
             >
               ↺ Retry
             </button>

--- a/components/PasswordGate.tsx
+++ b/components/PasswordGate.tsx
@@ -48,52 +48,75 @@ export function PasswordGate({ onAuth }: PasswordGateProps) {
   return (
     <div
       data-testid="password-gate"
-      className="fixed inset-0 z-50 flex flex-col items-center justify-center"
-      style={{ background: "#0a0a0f" }}
+      className="fixed inset-0 z-50 overflow-hidden"
+      style={{
+        background:
+          "radial-gradient(circle at top left, rgba(46, 211, 196, 0.2), transparent 28%), radial-gradient(circle at top right, rgba(243, 166, 59, 0.14), transparent 26%), linear-gradient(180deg, #061018 0%, #070d14 52%, #050a0f 100%)",
+      }}
     >
-      <div className="flex flex-col items-center gap-6 sm:gap-8 w-full max-w-sm px-6 sm:px-8">
-        {/* Wordmark */}
-        <div className="text-center">
-          <div className="text-3xl sm:text-4xl font-bold text-slate-100 tracking-tight">
-            supplie<span className="text-teal-400">.</span>
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute left-[12%] top-[18%] h-56 w-56 rounded-full bg-teal-400/10 blur-3xl animate-float-slow" />
+        <div className="absolute right-[10%] top-[12%] h-64 w-64 rounded-full bg-sky-400/10 blur-3xl animate-float-slower" />
+        <div className="absolute bottom-[10%] left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-amber-300/10 blur-3xl animate-float-slow" />
+      </div>
+
+      <div className="relative flex min-h-screen items-center justify-center px-6 py-10">
+        <div className="w-full max-w-md rounded-[30px] border border-white/12 bg-[rgba(6,12,18,0.78)] p-8 shadow-[0_30px_120px_rgba(2,6,14,0.55)] backdrop-blur-xl sm:p-10">
+          <div className="mb-8 text-center">
+            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-white/10 bg-[rgba(255,255,255,0.05)] px-3 py-1 text-[10px] font-medium uppercase tracking-[0.28em] text-slate-300">
+              Private Preview
+            </div>
+            <div className="text-4xl font-semibold tracking-[-0.04em] text-slate-50 sm:text-5xl">
+              supplie<span className="text-teal-400">.</span>
+            </div>
+            <div className="mt-2 text-xs uppercase tracking-[0.32em] text-slate-400">
+              Grounding Demo
+            </div>
+            <p className="mt-4 text-sm leading-6 text-slate-300">
+              Compare raw reasoning with tool-backed Supplie answers in a gated
+              demo environment.
+            </p>
           </div>
-          <div className="text-xs text-slate-500 uppercase tracking-widest mt-1 sm:mt-2">
-            Grounding Demo
+
+          <form
+            onSubmit={handleSubmit}
+            className={`space-y-4 ${shake ? "animate-shake" : ""}`}
+          >
+            <div className="rounded-2xl border border-white/10 bg-[rgba(255,255,255,0.04)] p-3">
+              <input
+                data-testid="password-input"
+                ref={inputRef}
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Enter demo password"
+                className="w-full rounded-[14px] border border-white/10 bg-slate-950/60 px-4 py-4 text-center text-sm tracking-[0.26em] text-slate-100 outline-none transition-colors placeholder:text-slate-500 focus:border-teal-400/50 focus:bg-slate-950/80"
+                autoComplete="current-password"
+              />
+            </div>
+            <button
+              data-testid="password-submit"
+              type="submit"
+              disabled={loading || !password.trim()}
+              className="w-full rounded-2xl border border-teal-300/20 bg-[linear-gradient(135deg,rgba(16,185,166,0.9),rgba(34,211,238,0.72))] py-4 text-sm font-semibold text-white shadow-[0_16px_40px_rgba(20,184,166,0.28)] transition-all hover:-translate-y-0.5 hover:shadow-[0_18px_48px_rgba(20,184,166,0.34)] disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {loading ? "Checking..." : "Enter"}
+            </button>
+            {error && (
+              <div
+                data-testid="password-error"
+                className="rounded-2xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-center text-sm text-red-300"
+              >
+                {error}
+              </div>
+            )}
+          </form>
+
+          <div className="mt-6 flex items-center justify-between gap-4 text-[11px] uppercase tracking-[0.18em] text-slate-500">
+            <span>Protected comparison</span>
+            <span>Invite-only access</span>
           </div>
         </div>
-
-        {/* Form */}
-        <form
-          onSubmit={handleSubmit}
-          className={`w-full space-y-3 ${shake ? "animate-shake" : ""}`}
-        >
-          <input
-            data-testid="password-input"
-            ref={inputRef}
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder="Enter demo password"
-            className="w-full bg-slate-900/80 text-slate-100 border border-slate-700/60 focus:border-teal-600/60 rounded-xl px-4 py-3.5 sm:py-4 text-base sm:text-sm outline-none transition-colors placeholder-slate-600 text-center tracking-widest"
-            autoComplete="current-password"
-          />
-          <button
-            data-testid="password-submit"
-            type="submit"
-            disabled={loading || !password.trim()}
-            className="w-full bg-teal-600/80 hover:bg-teal-500/80 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm sm:text-base font-medium rounded-xl py-3.5 sm:py-3 transition-colors"
-          >
-            {loading ? "Checking…" : "Enter"}
-          </button>
-          {error && (
-            <div
-              data-testid="password-error"
-              className="text-red-400 text-xs sm:text-sm text-center mt-2"
-            >
-              {error}
-            </div>
-          )}
-        </form>
       </div>
     </div>
   );

--- a/components/PromptButtons.tsx
+++ b/components/PromptButtons.tsx
@@ -13,17 +13,27 @@ const PROMPTS = [
 
 export function PromptButtons({ onPrompt, disabled }: PromptButtonsProps) {
   return (
-    <div className="flex gap-2 px-4 py-2 border-b border-white/5">
-      {PROMPTS.map((prompt, i) => (
-        <button
-          key={i}
-          onClick={() => onPrompt(prompt)}
-          disabled={disabled}
-          className="flex-1 text-xs text-slate-300 bg-slate-800/50 hover:bg-slate-700/60 border border-slate-700/50 hover:border-slate-500/60 rounded-full px-3 py-1.5 transition-all disabled:opacity-50 disabled:cursor-not-allowed text-center leading-tight"
-        >
-          {prompt}
-        </button>
-      ))}
+    <div className="rounded-[24px] border border-white/8 bg-white/4 px-3 py-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+      <div className="mb-2 flex items-center justify-between gap-3 px-2">
+        <div className="text-[11px] uppercase tracking-[0.22em] text-slate-500">
+          Demo prompts
+        </div>
+        <div className="text-[11px] text-slate-500">
+          One click mirrors the same prompt into both panels
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {PROMPTS.map((prompt, i) => (
+          <button
+            key={i}
+            onClick={() => onPrompt(prompt)}
+            disabled={disabled}
+            className="min-w-[260px] flex-1 rounded-full border border-slate-700/50 bg-[linear-gradient(180deg,rgba(20,29,42,0.86),rgba(13,19,29,0.86))] px-4 py-2.5 text-center text-xs leading-tight text-slate-200 transition-all hover:-translate-y-0.5 hover:border-slate-500/70 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {prompt}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/components/ToolCallCard.tsx
+++ b/components/ToolCallCard.tsx
@@ -51,48 +51,48 @@ export function ToolCallCard({
 
   return (
     <div
-      className={`border-l-2 ${hasError ? "border-red-600" : "border-teal-500"} ${hasError ? "bg-red-950/20" : "bg-teal-950/20"} rounded-r-lg mb-2 overflow-hidden animate-slide-in`}
+      className={`mb-2 overflow-hidden rounded-2xl border ${hasError ? "border-red-500/25 bg-red-500/10" : "border-teal-400/20 bg-[linear-gradient(180deg,rgba(11,42,43,0.42),rgba(5,18,22,0.55))]"} animate-slide-in shadow-[0_12px_32px_rgba(0,0,0,0.18)]`}
       style={{ animationDelay: `${index * 50}ms` }}
     >
       <button
         onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center gap-2 px-3 py-2 hover:bg-teal-950/30 transition-colors text-left"
+        className="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-white/4"
       >
         {expanded ? (
-          <ChevronDown className="w-3 h-3 text-teal-400 flex-shrink-0" />
+          <ChevronDown className="h-3 w-3 flex-shrink-0 text-teal-300" />
         ) : (
-          <ChevronRight className="w-3 h-3 text-teal-400 flex-shrink-0" />
+          <ChevronRight className="h-3 w-3 flex-shrink-0 text-teal-300" />
         )}
         {hasError && (
-          <AlertTriangle className="w-3 h-3 text-red-400 flex-shrink-0" />
+          <AlertTriangle className="h-3 w-3 flex-shrink-0 text-red-400" />
         )}
-        <span className="text-teal-300 font-mono text-xs font-semibold">
+        <span className="rounded-full border border-white/8 bg-white/5 px-2 py-0.5 font-mono text-[11px] font-semibold text-teal-200">
           {toolName}
         </span>
         <span
-          className={`font-mono text-xs ml-auto ${hasError ? "text-red-400" : "text-slate-400"}`}
+          className={`ml-auto font-mono text-[11px] ${hasError ? "text-red-300" : "text-slate-400"}`}
         >
           {getResultSummary()}
         </span>
       </button>
 
       {expanded && (
-        <div className="px-3 pb-3 space-y-2">
+        <div className="space-y-3 px-4 pb-4">
           <div>
-            <div className="text-xs text-slate-500 uppercase tracking-wider mb-1">
+            <div className="mb-1 text-[11px] uppercase tracking-[0.18em] text-slate-500">
               Inputs
             </div>
-            <pre className="text-xs text-slate-300 font-mono bg-black/30 rounded p-2 overflow-x-auto whitespace-pre-wrap">
+            <pre className="overflow-x-auto whitespace-pre-wrap rounded-xl border border-white/6 bg-black/25 p-3 font-mono text-xs text-slate-300">
               {formatValue(args)}
             </pre>
           </div>
           {result !== undefined && (
             <div>
-              <div className="text-xs text-slate-500 uppercase tracking-wider mb-1">
+              <div className="mb-1 text-[11px] uppercase tracking-[0.18em] text-slate-500">
                 Result
               </div>
               <pre
-                className={`text-xs font-mono bg-black/30 rounded p-2 overflow-x-auto whitespace-pre-wrap max-h-48 ${hasError ? "text-red-300" : "text-teal-200"}`}
+                className={`max-h-48 overflow-x-auto whitespace-pre-wrap rounded-xl border border-white/6 bg-black/25 p-3 font-mono text-xs ${hasError ? "text-red-200" : "text-teal-100"}`}
               >
                 {formatValue(result)}
               </pre>


### PR DESCRIPTION
## Summary
- refine the password gate with a more intentional branded card and atmospheric background
- elevate the authenticated shell with a polished top bar, prompt tray, and clearer live-comparison explainer
- restyle both comparison panels and grounded tool evidence for stronger visual hierarchy while preserving the two-panel contract

## Validation
- npm run lint
- npm run typecheck
- npm run build
- npm run test:e2e
- npm run visual:review

Closes #18