### PR TITLE
Fix #10: remove the bundled LangChain agent runtime

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,6 +1,6 @@
-import { AIMessageChunk } from "@langchain/core/messages";
 import { NextResponse } from "next/server";
 import { checkRateLimit } from "@/lib/server/rate-limit";
+import type { DemoAgentEvent } from "@/lib/server/demo-agent-runner";
 import { getGroundedAgent } from "@/lib/server/grounded-agent";
 import {
   createPlaywrightMockChatResponse,
@@ -17,6 +17,7 @@ import {
   getUngroundedAgent,
 } from "@/lib/server/ungrounded-agent";
 import { DEMO_PANEL_CONFIGS, type DemoAgentMode, type DemoProvider } from "@/lib/server/demo-config";
+import type { DemoRequestMessage } from "@/lib/server/demo-agent-runner";
 
 export const runtime = "nodejs";
 export const maxDuration = 120;
@@ -33,7 +34,7 @@ interface ChatRequestBody {
 }
 
 function normalizeMessages(body: ChatRequestBody) {
-  const normalized =
+  const normalized: DemoRequestMessage[] =
     body.messages
       ?.filter(
         (message): message is { role: string; content: string } =>
@@ -55,41 +56,6 @@ function normalizeMessages(body: ChatRequestBody) {
   }
 
   return normalized;
-}
-
-function extractTextDelta(chunk: unknown): string {
-  if (!AIMessageChunk.isInstance(chunk)) {
-    return "";
-  }
-
-  if (typeof chunk.content === "string") {
-    return chunk.content;
-  }
-
-  if (!Array.isArray(chunk.content)) {
-    return "";
-  }
-
-  return chunk.content
-    .map((block) => {
-      if (typeof block === "string") {
-        return block;
-      }
-
-      if (
-        typeof block === "object" &&
-        block !== null &&
-        "type" in block &&
-        block.type === "text" &&
-        "text" in block &&
-        typeof block.text === "string"
-      ) {
-        return block.text;
-      }
-
-      return "";
-    })
-    .join("");
 }
 
 function formatToolError(error: unknown): string {
@@ -158,54 +124,13 @@ export async function POST(req: Request) {
   const stream = new ReadableStream({
     async start(controller) {
       try {
-        const eventStream = agent.streamEvents(
-          { messages },
-          {
-            signal: req.signal,
-            version: "v2",
-          },
-        );
+        const eventStream = agent.streamResponse({
+          messages,
+          signal: req.signal,
+        });
 
         for await (const event of eventStream) {
-          if (event.event === "on_chat_model_stream") {
-            const delta = extractTextDelta(event.data?.chunk);
-            if (delta) {
-              controller.enqueue(encodeTextDelta(delta));
-            }
-          }
-
-          if (event.event === "on_tool_start") {
-            controller.enqueue(
-              encodeMetadata({
-                type: "tool-start",
-                toolCallId: event.run_id,
-                toolName: event.name,
-                args: event.data?.input ?? {},
-              }),
-            );
-          }
-
-          if (event.event === "on_tool_end") {
-            controller.enqueue(
-              encodeMetadata({
-                type: "tool-end",
-                toolCallId: event.run_id,
-                toolName: event.name,
-                result: event.data?.output,
-              }),
-            );
-          }
-
-          if (event.event === "on_tool_error") {
-            controller.enqueue(
-              encodeMetadata({
-                type: "tool-error",
-                toolCallId: event.run_id,
-                toolName: event.name,
-                error: formatToolError(event.data?.error),
-              }),
-            );
-          }
+          handleAgentEvent(controller, event);
         }
 
         controller.enqueue(encodeDone());
@@ -250,4 +175,47 @@ export async function POST(req: Request) {
       "X-Vercel-AI-Data-Stream": "v1",
     },
   });
+}
+
+function handleAgentEvent(
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  event: DemoAgentEvent,
+) {
+  if (event.type === "text-delta") {
+    controller.enqueue(encodeTextDelta(event.delta));
+    return;
+  }
+
+  if (event.type === "tool-start") {
+    controller.enqueue(
+      encodeMetadata({
+        type: "tool-start",
+        toolCallId: event.toolCallId,
+        toolName: event.toolName,
+        args: event.args ?? {},
+      }),
+    );
+    return;
+  }
+
+  if (event.type === "tool-end") {
+    controller.enqueue(
+      encodeMetadata({
+        type: "tool-end",
+        toolCallId: event.toolCallId,
+        toolName: event.toolName,
+        result: event.result,
+      }),
+    );
+    return;
+  }
+
+  controller.enqueue(
+    encodeMetadata({
+      type: "tool-error",
+      toolCallId: event.toolCallId,
+      toolName: event.toolName,
+      error: formatToolError(event.error),
+    }),
+  );
 }

--- a/lib/server/demo-agent-runner.test.ts
+++ b/lib/server/demo-agent-runner.test.ts
@@ -1,0 +1,123 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { AIMessage, AIMessageChunk } from "@langchain/core/messages";
+// @ts-ignore Node's built-in test runner needs the explicit .ts suffix here.
+import { createStreamingTextAgent, createToolAgent } from "./demo-agent-runner.ts";
+
+test("createStreamingTextAgent yields streamed text deltas", async () => {
+  const agent = createStreamingTextAgent({
+    systemPrompt: "You are helpful.",
+    model: {
+      async invoke() {
+        return new AIMessage({ content: "unused" });
+      },
+      async *stream() {
+        yield new AIMessageChunk({ content: "Hello" });
+        yield new AIMessageChunk({ content: " world" });
+      },
+    },
+  });
+
+  const deltas: string[] = [];
+  for await (const event of agent.streamResponse({
+    messages: [{ role: "user", content: "Hi" }],
+  })) {
+    assert.equal(event.type, "text-delta");
+    deltas.push(event.delta);
+  }
+
+  assert.deepEqual(deltas, ["Hello", " world"]);
+});
+
+test("createToolAgent runs tools and returns the final grounded answer", async () => {
+  let invocationCount = 0;
+
+  const agent = createToolAgent({
+    systemPrompt: "Use tools before answering.",
+    tools: [
+      {
+        name: "query_order_margin_snapshot",
+        async invoke(args) {
+          assert.deepEqual(args, {
+            customer: "Suspension King",
+            period: "last_week",
+          });
+
+          return {
+            net_margin: 7990,
+            customer: "Suspension King",
+          };
+        },
+      },
+    ],
+    model: {
+      async invoke() {
+        invocationCount += 1;
+
+        if (invocationCount === 1) {
+          return new AIMessage({
+            content: "",
+            tool_calls: [
+              {
+                id: "tool-1",
+                name: "query_order_margin_snapshot",
+                type: "tool_call",
+                args: {
+                  customer: "Suspension King",
+                  period: "last_week",
+                },
+              },
+            ],
+          });
+        }
+
+        return new AIMessage({
+          content:
+            "The Supplie demo snapshot shows Suspension King's net margin is 7,990.",
+        });
+      },
+      bindTools() {
+        return this;
+      },
+    },
+  });
+
+  const events = [];
+  for await (const event of agent.streamResponse({
+    messages: [
+      {
+        role: "user",
+        content:
+          "What's the net margin on last week's Suspension King orders after freight and rebates?",
+      },
+    ],
+  })) {
+    events.push(event);
+  }
+
+  assert.deepEqual(events, [
+    {
+      type: "tool-start",
+      toolCallId: "tool-1",
+      toolName: "query_order_margin_snapshot",
+      args: {
+        customer: "Suspension King",
+        period: "last_week",
+      },
+    },
+    {
+      type: "tool-end",
+      toolCallId: "tool-1",
+      toolName: "query_order_margin_snapshot",
+      result: {
+        net_margin: 7990,
+        customer: "Suspension King",
+      },
+    },
+    {
+      type: "text-delta",
+      delta:
+        "The Supplie demo snapshot shows Suspension King's net margin is 7,990.",
+    },
+  ]);
+});

--- a/lib/server/demo-agent-runner.ts
+++ b/lib/server/demo-agent-runner.ts
@@ -1,0 +1,272 @@
+import {
+  AIMessage,
+  AIMessageChunk,
+  HumanMessage,
+  SystemMessage,
+  ToolMessage,
+} from "@langchain/core/messages";
+
+export interface DemoRequestMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface DemoAgentOptions {
+  messages: DemoRequestMessage[];
+  signal?: AbortSignal;
+}
+
+export interface TextDeltaEvent {
+  type: "text-delta";
+  delta: string;
+}
+
+export interface ToolStartEvent {
+  type: "tool-start";
+  toolCallId: string;
+  toolName: string;
+  args: unknown;
+}
+
+export interface ToolEndEvent {
+  type: "tool-end";
+  toolCallId: string;
+  toolName: string;
+  result: unknown;
+}
+
+export interface ToolErrorEvent {
+  type: "tool-error";
+  toolCallId: string;
+  toolName: string;
+  error: string;
+}
+
+export type DemoAgentEvent =
+  | TextDeltaEvent
+  | ToolStartEvent
+  | ToolEndEvent
+  | ToolErrorEvent;
+
+export interface DemoAgent {
+  streamResponse(
+    options: DemoAgentOptions,
+  ): AsyncGenerator<DemoAgentEvent, void, void>;
+}
+
+interface DemoTool {
+  name: string;
+  invoke(
+    input: unknown,
+    options?: { signal?: AbortSignal },
+  ): Promise<unknown> | unknown;
+}
+
+interface InvokeOnlyModel {
+  invoke(
+    messages: Array<HumanMessage | AIMessage | SystemMessage | ToolMessage>,
+    options?: { signal?: AbortSignal },
+  ): Promise<AIMessage>;
+}
+
+interface StreamCapableModel extends InvokeOnlyModel {
+  stream?:
+    | ((
+        messages: Array<HumanMessage | AIMessage | SystemMessage | ToolMessage>,
+        options?: { signal?: AbortSignal },
+      ) => AsyncIterable<AIMessageChunk> | Promise<AsyncIterable<AIMessageChunk>>)
+    | undefined;
+}
+
+interface ToolBindableModel extends StreamCapableModel {
+  bindTools?: ((tools: DemoTool[]) => InvokeOnlyModel) | undefined;
+}
+
+function toConversationMessages(messages: DemoRequestMessage[]) {
+  return messages.map((message) =>
+    message.role === "assistant"
+      ? new AIMessage({ content: message.content })
+      : new HumanMessage({ content: message.content }),
+  );
+}
+
+function extractTextContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content
+    .map((block) => {
+      if (typeof block === "string") {
+        return block;
+      }
+
+      if (
+        typeof block === "object" &&
+        block !== null &&
+        "type" in block &&
+        block.type === "text" &&
+        "text" in block &&
+        typeof block.text === "string"
+      ) {
+        return block.text;
+      }
+
+      return "";
+    })
+    .join("");
+}
+
+function stringifyToolResult(result: unknown): string {
+  if (typeof result === "string") {
+    return result;
+  }
+
+  const serialized = JSON.stringify(result, null, 2);
+  return serialized ?? String(result);
+}
+
+export function createStreamingTextAgent(options: {
+  model: StreamCapableModel;
+  systemPrompt: string;
+}): DemoAgent {
+  const { model, systemPrompt } = options;
+
+  return {
+    async *streamResponse({ messages, signal }) {
+      const conversation = [
+        new SystemMessage(systemPrompt),
+        ...toConversationMessages(messages),
+      ];
+
+      if (!model.stream) {
+        const response = await model.invoke(conversation, { signal });
+        const text = extractTextContent(response.content);
+        if (text) {
+          yield { type: "text-delta", delta: text };
+        }
+        return;
+      }
+
+      const stream = await model.stream(conversation, { signal });
+      for await (const chunk of stream) {
+        const delta = extractTextContent(chunk.content);
+        if (delta) {
+          yield { type: "text-delta", delta };
+        }
+      }
+    },
+  };
+}
+
+export function createToolAgent(options: {
+  model: ToolBindableModel;
+  systemPrompt: string;
+  tools: DemoTool[];
+  maxIterations?: number;
+}): DemoAgent {
+  const { model, systemPrompt, tools, maxIterations = 4 } = options;
+
+  if (!model.bindTools) {
+    throw new Error("Model does not support tool binding.");
+  }
+
+  const toolEnabledModel = model.bindTools(tools);
+  const toolMap = new Map(tools.map((tool) => [tool.name, tool]));
+
+  return {
+    async *streamResponse({ messages, signal }) {
+      let conversation: Array<
+        HumanMessage | AIMessage | SystemMessage | ToolMessage
+      > = [new SystemMessage(systemPrompt), ...toConversationMessages(messages)];
+
+      for (let step = 0; step < maxIterations; step += 1) {
+        const response = await toolEnabledModel.invoke(conversation, { signal });
+        const text = extractTextContent(response.content);
+
+        if (text) {
+          yield { type: "text-delta", delta: text };
+        }
+
+        const toolCalls = response.tool_calls ?? [];
+        if (toolCalls.length === 0) {
+          return;
+        }
+
+        conversation = [...conversation, response];
+
+        for (const toolCall of toolCalls) {
+          const toolName = toolCall.name;
+          const toolCallId = toolCall.id ?? `${toolName}-${step}`;
+          const tool = toolMap.get(toolName);
+
+          if (!tool) {
+            const error = `Tool "${toolName}" is not available.`;
+            yield {
+              type: "tool-error",
+              toolCallId,
+              toolName,
+              error,
+            };
+            conversation.push(
+              new ToolMessage({
+                tool_call_id: toolCallId,
+                name: toolName,
+                content: error,
+              }),
+            );
+            continue;
+          }
+
+          yield {
+            type: "tool-start",
+            toolCallId,
+            toolName,
+            args: toolCall.args,
+          };
+
+          try {
+            const result = await tool.invoke(toolCall.args, { signal });
+            yield {
+              type: "tool-end",
+              toolCallId,
+              toolName,
+              result,
+            };
+            conversation.push(
+              new ToolMessage({
+                tool_call_id: toolCallId,
+                name: toolName,
+                content: stringifyToolResult(result),
+              }),
+            );
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            yield {
+              type: "tool-error",
+              toolCallId,
+              toolName,
+              error: message,
+            };
+            conversation.push(
+              new ToolMessage({
+                tool_call_id: toolCallId,
+                name: toolName,
+                content: message,
+              }),
+            );
+          }
+        }
+      }
+
+      throw new Error(
+        "Grounded agent exceeded the maximum number of tool iterations.",
+      );
+    },
+  };
+}

--- a/lib/server/grounded-agent.ts
+++ b/lib/server/grounded-agent.ts
@@ -1,5 +1,4 @@
 import { tool } from "@langchain/core/tools";
-import { createAgent } from "langchain";
 import { z } from "zod";
 import {
   GROUNDED_CAPABILITIES,
@@ -7,6 +6,7 @@ import {
 } from "./demo-capabilities";
 import type { DemoProvider } from "./demo-config";
 import { getChatModel } from "./chat-model";
+import { createToolAgent } from "./demo-agent-runner";
 
 interface GroundedAgentOptions {
   model: string;
@@ -303,7 +303,7 @@ const groundedTools = [
   ),
 ];
 
-const agentCache = new Map<string, ReturnType<typeof createAgent>>();
+const agentCache = new Map<string, ReturnType<typeof createToolAgent>>();
 
 function buildSystemPrompt(): string {
   return [
@@ -326,7 +326,7 @@ export function getGroundedAgent(options: GroundedAgentOptions) {
     return cached;
   }
 
-  const agent = createAgent({
+  const agent = createToolAgent({
     model: getChatModel(options),
     tools: groundedTools,
     systemPrompt: buildSystemPrompt(),

--- a/lib/server/ungrounded-agent.ts
+++ b/lib/server/ungrounded-agent.ts
@@ -1,17 +1,20 @@
-import { createAgent } from "langchain";
 import {
   UNGROUNDED_CAPABILITIES,
   getCapabilitySummaryLines,
 } from "./demo-capabilities";
 import type { DemoProvider } from "./demo-config";
 import { getChatModel } from "./chat-model";
+import { createStreamingTextAgent } from "./demo-agent-runner";
 
 interface UngroundedAgentOptions {
   model: string;
   provider: DemoProvider;
 }
 
-const agentCache = new Map<string, ReturnType<typeof createAgent>>();
+const agentCache = new Map<
+  string,
+  ReturnType<typeof createStreamingTextAgent>
+>();
 
 function buildSystemPrompt(): string {
   return [
@@ -47,9 +50,8 @@ export function getUngroundedAgent(options: UngroundedAgentOptions) {
     return cached;
   }
 
-  const agent = createAgent({
+  const agent = createStreamingTextAgent({
     model: getChatModel(options),
-    tools: [],
     systemPrompt: buildSystemPrompt(),
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@langchain/anthropic": "^1.3.25",
         "@langchain/core": "^1.1.36",
         "@langchain/openai": "^1.3.1",
-        "langchain": "^1.2.37",
         "lucide-react": "^0.577.0",
         "next": "16.2.1",
         "react": "19.2.4",
@@ -1147,155 +1146,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/@langchain/langgraph": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.6.tgz",
-      "integrity": "sha512-5cX402dNGN6w9+0mlMU2dgUiKx6Y1tlENp7x05e9ByDbQCHSDc0kyqRWNFLGc7vatQ92S4ylxQrcCJvi8Fr4SQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@langchain/langgraph-checkpoint": "^1.0.1",
-        "@langchain/langgraph-sdk": "~1.8.1",
-        "@standard-schema/spec": "1.1.0",
-        "uuid": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@langchain/core": "^1.1.16",
-        "zod": "^3.25.32 || ^4.2.0",
-        "zod-to-json-schema": "^3.x"
-      },
-      "peerDependenciesMeta": {
-        "zod-to-json-schema": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@langchain/langgraph-checkpoint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.1.tgz",
-      "integrity": "sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==",
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@langchain/core": "^1.0.1"
-      }
-    },
-    "node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.8.2.tgz",
-      "integrity": "sha512-TQSw5O0NiE0W6D+UKcv6AdvCqQD2Xbv96oaUFUSSL3nnQ0WfZLcF5nPNTQm6KLUo4EuhKZeeoAgnDb2hRDW2Hw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15",
-        "p-queue": "^9.0.1",
-        "p-retry": "^7.1.1",
-        "uuid": "^13.0.0"
-      },
-      "peerDependencies": {
-        "@langchain/core": "^1.1.16",
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19",
-        "svelte": "^4.0.0 || ^5.0.0",
-        "vue": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@langchain/core": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@langchain/langgraph-sdk/node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
-    },
-    "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
-      "integrity": "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "p-timeout": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@langchain/langgraph-sdk/node_modules/p-timeout": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
-      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "node_modules/@langchain/langgraph/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@langchain/openai": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.3.1.tgz",
@@ -1924,6 +1774,7 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -4667,18 +4518,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-network-error": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
-      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5006,25 +4845,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/langchain": {
-      "version": "1.2.37",
-      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.2.37.tgz",
-      "integrity": "sha512-zjd0TpMfX8V440XJVavRmzLSvojVv5WZ7M9LWNtgYo0MDFTiWlCdnFNdHo1sZlNoI+8aSdLsVl/WXKtucyhwEA==",
-      "license": "MIT",
-      "dependencies": {
-        "@langchain/langgraph": "^1.1.2",
-        "@langchain/langgraph-checkpoint": "^1.0.0",
-        "langsmith": ">=0.5.0 <1.0.0",
-        "uuid": "^11.1.0",
-        "zod": "^3.25.76 || ^4"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@langchain/core": "^1.1.36"
       }
     },
     "node_modules/langsmith": {
@@ -5913,21 +5733,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-retry": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
-      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
-      "license": "MIT",
-      "dependencies": {
-        "is-network-error": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@langchain/anthropic": "^1.3.25",
     "@langchain/core": "^1.1.36",
     "@langchain/openai": "^1.3.1",
-    "langchain": "^1.2.37",
     "lucide-react": "^0.577.0",
     "next": "16.2.1",
     "react": "19.2.4",


### PR DESCRIPTION
## Summary
- replace the `langchain` `createAgent` runtime with a small explicit server-side runner built on `@langchain/openai`, `@langchain/anthropic`, and `@langchain/core`
- keep the grounded tool flow, but execute tool calls in app code so the production bundle no longer pulls in LangChain's dynamic universal model-loader path
- add a focused regression test for the grounded tool loop and remove the direct `langchain` dependency from the app

## Root cause
PR #14 fixed the *input model object* but not the *agent runtime*. The app still imported `createAgent` from `langchain`, and the Next 16/Turbopack production bundle still embedded LangChain's dynamic model-loader path. In the deployed standalone image that path is what surfaced as `Cannot find module as expression is too dynamic`.

The earlier local validation missed this because it exercised the app from the repo checkout with the full workspace dependency tree available, not the isolated standalone artifact that the container actually runs.

## Validation
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- verified the built server output no longer contains `Cannot find module as expression is too dynamic`
- copied `.next/standalone` into an isolated temp dir and ran `node server.js` there with an OpenAI-compatible local stub
- hit `POST /api/chat` on that isolated standalone server and confirmed the grounded flow emitted the tool call, returned `net_margin":7990`, and streamed the final answer `The Supplie demo snapshot shows Suspension King's net margin is 7,990.`

Closes #10
