### PR TITLE
Rebrand active demo copy to Annona

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,17 @@
-# Supplie Demo — Architecture Notes
+# Annona Demo — Architecture Notes
 
 ## Current Architecture
 
 - This is now a **two-agent demo slice**.
 - The frontend keeps the two-panel comparison layout.
 - The left panel runs the **ungrounded / raw** LangChain agent.
-- The right panel runs the **grounded Supplie** agent with built-in demo tools.
+- The right panel runs the **grounded Annona** agent with built-in demo tools.
 
 ## Supported Today
 
 - OpenAI and Anthropic model selection
 - Streamed text responses
-- Right-panel Supplie demo snapshot tools for:
+- Right-panel Annona demo snapshot tools for:
   - order margin lookup with freight and rebates
   - 30-day stockout risk checks
   - supplier margin leakage ranking
@@ -24,7 +24,7 @@
 - Code sandbox execution
 - File access or generated file downloads
 
-The grounded panel uses a static bundled demo snapshot. It must not imply live operational access until real Supplie integrations exist.
+The grounded panel uses a static bundled demo snapshot. It must not imply live operational access until real Annona integrations exist.
 
 ## Env Vars
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Supplie Demo
+# Annona Demo
 
 This repo is a Next.js demo frontend with two side-by-side demo agents.
 
@@ -6,11 +6,11 @@ This repo is a Next.js demo frontend with two side-by-side demo agents.
 
 - The UI keeps the two-panel side-by-side demo layout.
 - The left panel is an **ungrounded / raw** agent.
-- The right panel is a **grounded Supplie** agent backed by built-in demo tools.
+- The right panel is a **grounded Annona** agent backed by built-in demo tools.
 - Streaming text is supported on both sides.
-- The grounded side uses a static bundled Supplie demo snapshot, not live production data.
+- The grounded side uses a static bundled Annona demo snapshot, not live production data.
 - When an OpenAI model is selected, the raw panel can use native OpenAI web search, a sandboxed code interpreter, and bundled file workflows over a small static demo file set.
-- The raw panel still does **not** have grounded Supplie tools or live ERP / warehouse access.
+- The raw panel still does **not** have grounded Annona tools or live ERP / warehouse access.
 - The grounded panel still does **not** have browsing, code execution, or OpenAI file workflows.
 
 Both agents are instructed to say when required data or capabilities are missing instead of pretending they exist.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Supplie.ai — Grounding Demo",
-  description: "Supplie.ai Grounding Demo for Zeder Corporation",
+  title: "Annona — Grounding Demo",
+  description: "Annona Grounding Demo for Zeder Corporation",
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,8 +35,8 @@ const DEFAULT_CONFIG: Omit<DemoConfig, "anthropicAvailable"> = {
   comparisonMode: "dual-agent",
   sharedLimitations: [
     "No live ERP or warehouse connectivity.",
-    "The grounded panel is limited to the bundled Supplie snapshot and does not browse, execute code, or use OpenAI file workflows.",
-    "The raw panel never has live Supplie systems or grounded Supplie snapshot tools.",
+    "The grounded panel is limited to the bundled Annona snapshot and does not browse, execute code, or use OpenAI file workflows.",
+    "The raw panel never has live Annona systems or grounded Annona snapshot tools.",
   ],
   panels: [
     {
@@ -46,10 +46,10 @@ const DEFAULT_CONFIG: Omit<DemoConfig, "anthropicAvailable"> = {
       badgeColor: "amber",
       backendLabel: "OpenAI Responses raw agent",
       description:
-        "Ungrounded relative to Supplie data, but the raw panel can use native OpenAI web search, bundled file workflows, and a sandboxed code interpreter.",
+        "Ungrounded relative to Annona data, but the raw panel can use native OpenAI web search, bundled file workflows, and a sandboxed code interpreter.",
       emptyStateTitle: "Raw comparison output appears here",
       emptyStateDetail:
-        "With an OpenAI model selected, this panel can show native web, file, and code tool use while staying ungrounded relative to Supplie data.",
+        "With an OpenAI model selected, this panel can show native web, file, and code tool use while staying ungrounded relative to Annona data.",
       capabilities: [
         {
           id: "streaming_text",
@@ -86,15 +86,15 @@ const DEFAULT_CONFIG: Omit<DemoConfig, "anthropicAvailable"> = {
     },
     {
       id: "grounded",
-      title: "Grounded Supplie Agent",
-      badge: "Supplie tools",
+      title: "Grounded Annona Agent",
+      badge: "Annona tools",
       badgeColor: "teal",
-      backendLabel: "Supplie grounded demo agent",
+      backendLabel: "Annona grounded demo agent",
       description:
-        "Uses built-in Supplie demo tools against a static bundled snapshot. No live ERP, browsing, code execution, or file access.",
+        "Uses built-in Annona demo tools against a static bundled snapshot. No live ERP, browsing, code execution, or file access.",
       emptyStateTitle: "Grounded tool-backed answers appear here",
       emptyStateDetail:
-        "This panel can query the bundled Supplie demo snapshot and should say when a question falls outside that data.",
+        "This panel can query the bundled Annona demo snapshot and should say when a question falls outside that data.",
       capabilities: [
         {
           id: "streaming_text",
@@ -105,11 +105,11 @@ const DEFAULT_CONFIG: Omit<DemoConfig, "anthropicAvailable"> = {
         },
         {
           id: "supplie_demo_tools",
-          label: "Supplie demo snapshot tools",
+          label: "Annona demo snapshot tools",
           enabled: true,
           availability: "available",
           description:
-            "The grounded panel can query built-in Supplie demo data tools against a static snapshot bundled with this app.",
+            "The grounded panel can query built-in Annona demo data tools against a static snapshot bundled with this app.",
         },
       ],
     },
@@ -322,7 +322,7 @@ export default function Home() {
                     className="text-sm font-semibold"
                     style={{ color: "var(--text-primary)" }}
                   >
-                    Supplie.ai
+                    Annona
                   </span>
                   <span
                     className="text-[11px] uppercase tracking-[0.24em]"
@@ -333,7 +333,7 @@ export default function Home() {
                 </div>
                 <div className="text-sm text-slate-400">
                   Demo-quality side-by-side review of raw reasoning vs grounded
-                  Supplie output.
+                  Annona output.
                 </div>
               </div>
             </div>
@@ -360,7 +360,7 @@ export default function Home() {
               </div>
               <div className="mt-2 text-sm leading-6 text-slate-100">
                 Left panel stays raw on {ungroundedPanel.backendLabel}. Right
-                panel runs {groundedPanel.backendLabel} with bundled Supplie
+                panel runs {groundedPanel.backendLabel} with bundled Annona
                 snapshot tools.
               </div>
               <div className="mt-3 flex flex-wrap gap-2 text-xs">

--- a/components/PasswordGate.tsx
+++ b/components/PasswordGate.tsx
@@ -67,13 +67,13 @@ export function PasswordGate({ onAuth }: PasswordGateProps) {
               Private Preview
             </div>
             <div className="text-4xl font-semibold tracking-[-0.04em] text-slate-50 sm:text-5xl">
-              supplie<span className="text-teal-400">.</span>
+              Annona<span className="text-teal-400">.</span>
             </div>
             <div className="mt-2 text-xs uppercase tracking-[0.32em] text-slate-400">
               Grounding Demo
             </div>
             <p className="mt-4 text-sm leading-6 text-slate-300">
-              Compare raw reasoning with tool-backed Supplie answers in a gated
+              Compare raw reasoning with tool-backed Annona answers in a gated
               demo environment.
             </p>
           </div>

--- a/data/ungrounded-openai/raw-agent-capability-notes.md
+++ b/data/ungrounded-openai/raw-agent-capability-notes.md
@@ -5,7 +5,7 @@ These files exist only to demonstrate OpenAI-native file workflows on the ungrou
 Important limits:
 
 - They are static demo assets bundled with the app.
-- They are not live Supplie ERP, warehouse, or customer data.
+- They are not live Annona ERP, warehouse, or customer data.
 - They are not a general local filesystem browser.
 - They are not a user-upload flow.
 
@@ -14,4 +14,4 @@ Bundled files in this demo:
 - `raw-agent-capability-notes.md`: this note.
 - `global_freight_benchmarks.csv`: a small illustrative supply-chain benchmark table.
 
-If a user asks whether these files are live or Supplie-specific, the answer should be no.
+If a user asks whether these files are live or Annona-specific, the answer should be no.

--- a/docs/site-prd-demo-plan.md
+++ b/docs/site-prd-demo-plan.md
@@ -1,14 +1,14 @@
-# Supplie Demo Site PRD / Visual Review Rubric
+# Annona Demo Site PRD / Visual Review Rubric
 
-This document is the CI visual-review rubric for the current Supplie demo slice.
+This document is the CI visual-review rubric for the current Annona demo slice.
 It consolidates the accepted product intent from issues `#7`, `#11`, and `#12`
 into a deterministic checklist that GPT-5.4 can evaluate against screenshots.
 
 ## Product Intent
 
 - The demo must present a trustworthy side-by-side comparison between two agents.
-- The left panel is the ungrounded / raw agent and must stay ungrounded relative to Supplie data.
-- The right panel is the grounded Supplie agent and must show Supplie snapshot
+- The left panel is the ungrounded / raw agent and must stay ungrounded relative to Annona data.
+- The right panel is the grounded Annona agent and must show Annona snapshot
   tooling behavior.
 - The UI must disclose capabilities and limitations truthfully instead of
   implying unavailable features.
@@ -19,19 +19,19 @@ into a deterministic checklist that GPT-5.4 can evaluate against screenshots.
 ### 1. Locked Entry
 
 - The password gate fills the viewport.
-- The Supplie wordmark and `Grounding Demo` subtitle are visible.
+- The Annona wordmark and `Grounding Demo` subtitle are visible.
 - A centered password input and primary `Enter` button are visible.
 - The protected comparison UI is not visible behind the gate.
 
 ### 2. Authenticated Comparison
 
-- The top bar shows `Supplie.ai`, `Grounding Demo`, the model picker, and the
+- The top bar shows `Annona`, `Grounding Demo`, the model picker, and the
   clear button.
 - Prompt chips are visible beneath the top bar.
 - A `Live Comparison` explainer is visible.
 - Two equal-width panels are visible side by side on desktop.
 - The left panel title is `Ungrounded / Raw Agent`.
-- The right panel title is `Grounded Supplie Agent`.
+- The right panel title is `Grounded Annona Agent`.
 - Amber styling is used for the raw side and teal styling is used for the
   grounded side.
 - Empty states are readable and visually balanced.
@@ -39,9 +39,9 @@ into a deterministic checklist that GPT-5.4 can evaluate against screenshots.
 ### 3. Post-Prompt Response
 
 - The same user prompt appears in both panels.
-- The left panel response is visibly framed as ungrounded relative to Supplie data.
-- The right panel response is visibly framed as grounded Supplie output.
-- The grounded panel includes tool evidence for the Supplie snapshot lookup.
+- The left panel response is visibly framed as ungrounded relative to Annona data.
+- The right panel response is visibly framed as grounded Annona output.
+- The grounded panel includes tool evidence for the Annona snapshot lookup.
 - The grounded result references the snapshot finding for `Suspension King`.
 
 ## Visual Acceptance Criteria
@@ -51,7 +51,7 @@ into a deterministic checklist that GPT-5.4 can evaluate against screenshots.
 - `comparison_layout`: the desktop layout clearly communicates a left-vs-right
   comparison without clipped, overlapping, or collapsed regions.
 - `truthful_disclosure`: labels, explainer copy, and panel notes do not
-  overclaim live ERP, Supplie grounding, arbitrary filesystem access, or other
+  overclaim live ERP, Annona grounding, arbitrary filesystem access, or other
   missing capabilities.
 - `grounded_evidence_visibility`: the grounded panel makes its tool-backed
   evidence visually distinct from the raw panel.

--- a/lib/server/demo-agent-runner.test.ts
+++ b/lib/server/demo-agent-runner.test.ts
@@ -73,7 +73,7 @@ test("createToolAgent runs tools and returns the final grounded answer", async (
 
         return new AIMessage({
           content:
-            "The Supplie demo snapshot shows Suspension King's net margin is 7,990.",
+            "The Annona demo snapshot shows Suspension King's net margin is 7,990.",
         });
       },
       bindTools() {
@@ -117,7 +117,7 @@ test("createToolAgent runs tools and returns the final grounded answer", async (
     {
       type: "text-delta",
       delta:
-        "The Supplie demo snapshot shows Suspension King's net margin is 7,990.",
+        "The Annona demo snapshot shows Suspension King's net margin is 7,990.",
     },
   ]);
 });

--- a/lib/server/demo-capabilities.ts
+++ b/lib/server/demo-capabilities.ts
@@ -33,11 +33,11 @@ export function getUngroundedCapabilities(
     },
     {
       id: "supplie_demo_tools",
-      label: "Supplie demo snapshot tools",
+      label: "Annona demo snapshot tools",
       enabled: false,
       availability: "planned",
       description:
-        "The raw panel never uses grounded Supplie snapshot tools and must stay ungrounded relative to Supplie data.",
+        "The raw panel never uses grounded Annona snapshot tools and must stay ungrounded relative to Annona data.",
     },
     {
       id: "live_systems",
@@ -45,7 +45,7 @@ export function getUngroundedCapabilities(
       enabled: false,
       availability: "planned",
       description:
-        "No live operational systems are connected. Do not imply access to current Supplie data.",
+        "No live operational systems are connected. Do not imply access to current Annona data.",
     },
     {
       id: "native_web_search",
@@ -93,11 +93,11 @@ export const GROUNDED_CAPABILITIES: DemoCapability[] = [
   },
   {
     id: "supplie_demo_tools",
-    label: "Supplie demo snapshot tools",
+    label: "Annona demo snapshot tools",
     enabled: true,
     availability: "available",
     description:
-      "The grounded panel can query built-in Supplie demo data tools against a static snapshot bundled with this app.",
+      "The grounded panel can query built-in Annona demo data tools against a static snapshot bundled with this app.",
   },
   {
     id: "live_systems",
@@ -113,7 +113,7 @@ export const GROUNDED_CAPABILITIES: DemoCapability[] = [
     enabled: false,
     availability: "planned",
     description:
-      "Not available on the grounded panel. It stays limited to bundled Supplie snapshot tools only.",
+      "Not available on the grounded panel. It stays limited to bundled Annona snapshot tools only.",
   },
   {
     id: "code_sandbox",

--- a/lib/server/demo-config.ts
+++ b/lib/server/demo-config.ts
@@ -37,11 +37,11 @@ export function getDemoPanelConfigs(
         ? "OpenAI Responses raw agent"
         : "LangChain ungrounded agent",
       description: openaiRaw
-        ? "Ungrounded relative to Supplie data, but the raw panel can use native OpenAI web search, bundled file workflows, and a sandboxed code interpreter."
-        : "Answers from general reasoning only. No grounded Supplie data tools or OpenAI native tools are available on this side.",
+        ? "Ungrounded relative to Annona data, but the raw panel can use native OpenAI web search, bundled file workflows, and a sandboxed code interpreter."
+        : "Answers from general reasoning only. No grounded Annona data tools or OpenAI native tools are available on this side.",
       emptyStateTitle: "Raw comparison output appears here",
       emptyStateDetail: openaiRaw
-        ? "With an OpenAI model selected, this panel can show native web, file, and code tool use while staying ungrounded relative to Supplie data."
+        ? "With an OpenAI model selected, this panel can show native web, file, and code tool use while staying ungrounded relative to Annona data."
         : "This panel stays ungrounded and should disclose when a question needs real data or tools.",
       capabilities: getUngroundedCapabilities(
         provider,
@@ -50,15 +50,15 @@ export function getDemoPanelConfigs(
     },
     grounded: {
       id: "grounded",
-      title: "Grounded Supplie Agent",
-      badge: "Supplie tools",
+      title: "Grounded Annona Agent",
+      badge: "Annona tools",
       badgeColor: "teal",
-      backendLabel: "Supplie grounded demo agent",
+      backendLabel: "Annona grounded demo agent",
       description:
-        "Uses built-in Supplie demo tools against a static bundled snapshot. No live ERP, browsing, code execution, or file access.",
+        "Uses built-in Annona demo tools against a static bundled snapshot. No live ERP, browsing, code execution, or file access.",
       emptyStateTitle: "Grounded tool-backed answers appear here",
       emptyStateDetail:
-        "This panel can query the bundled Supplie demo snapshot and should say when a question falls outside that data.",
+        "This panel can query the bundled Annona demo snapshot and should say when a question falls outside that data.",
       capabilities: GROUNDED_CAPABILITIES,
     },
   };
@@ -75,8 +75,8 @@ export function getPublicDemoConfig(
     panels: [panels.ungrounded, panels.grounded] satisfies DemoPanelConfig[],
     sharedLimitations: [
       "No live ERP or warehouse connectivity.",
-      "The grounded panel is limited to the bundled Supplie snapshot and does not browse, execute code, or use OpenAI file workflows.",
-      "The raw panel never has live Supplie systems or grounded Supplie snapshot tools.",
+      "The grounded panel is limited to the bundled Annona snapshot and does not browse, execute code, or use OpenAI file workflows.",
+      "The raw panel never has live Annona systems or grounded Annona snapshot tools.",
     ],
   };
 }

--- a/lib/server/grounded-agent.ts
+++ b/lib/server/grounded-agent.ts
@@ -47,7 +47,7 @@ const DEMO_SNAPSHOT = {
   snapshot_id: "supplie-demo-snapshot-2026-03-22",
   captured_at: "2026-03-22T18:00:00Z",
   disclosure:
-    "This is a static Supplie demo snapshot bundled with the app. It is not live production data.",
+    "This is a static Annona demo snapshot bundled with the app. It is not live production data.",
   orders: [
     {
       order_id: "SK-240317-01",
@@ -165,7 +165,7 @@ const groundedTools = [
     {
       name: "get_supplie_demo_snapshot_context",
       description:
-        "Use to confirm what the grounded Supplie demo snapshot contains and how it should be disclosed.",
+        "Use to confirm what the grounded Annona demo snapshot contains and how it should be disclosed.",
       schema: z.object({}),
     },
   ),
@@ -223,7 +223,7 @@ const groundedTools = [
     {
       name: "query_order_margin_snapshot",
       description:
-        "Look up grounded order margin data from the Supplie demo snapshot, including freight and rebate impacts.",
+        "Look up grounded order margin data from the Annona demo snapshot, including freight and rebate impacts.",
       schema: z.object({
         customer: z
           .string()
@@ -255,7 +255,7 @@ const groundedTools = [
     {
       name: "query_stockout_risk_snapshot",
       description:
-        "Return grounded SKU stockout risks from the Supplie demo snapshot for the requested planning horizon.",
+        "Return grounded SKU stockout risks from the Annona demo snapshot for the requested planning horizon.",
       schema: z.object({
         horizon_days: z
           .number()
@@ -289,7 +289,7 @@ const groundedTools = [
     {
       name: "query_supplier_margin_leakage_snapshot",
       description:
-        "Rank suppliers by margin leakage using the grounded Supplie demo snapshot.",
+        "Rank suppliers by margin leakage using the grounded Annona demo snapshot.",
       schema: z.object({
         top_n: z
           .number()
@@ -307,12 +307,12 @@ const agentCache = new Map<string, ReturnType<typeof createToolAgent>>();
 
 function buildSystemPrompt(): string {
   return [
-    "You are the grounded Supplie demo agent for a supply-chain comparison demo.",
-    "Always use the supplied Supplie demo tools before answering any question that asks for numbers, rankings, order details, stock risk, or supplier leakage.",
-    "Your grounded data is limited to the bundled Supplie demo snapshot. It is not live production data.",
+    "You are the grounded Annona demo agent for a supply-chain comparison demo.",
+    "Always use the supplied Annona demo tools before answering any question that asks for numbers, rankings, order details, stock risk, or supplier leakage.",
+    "Your grounded data is limited to the bundled Annona demo snapshot. It is not live production data.",
     "Never claim to have accessed the web, code execution, files, or live ERP / warehouse systems unless a real tool in this run did that. Those capabilities are not available here.",
     "If the user asks for something outside the bundled snapshot, say what is missing and keep the limitation explicit.",
-    "When you answer from the grounded snapshot, mention that it came from the Supplie demo snapshot.",
+    "When you answer from the grounded snapshot, mention that it came from the Annona demo snapshot.",
     "",
     "Current runtime capability status:",
     ...getCapabilitySummaryLines(GROUNDED_CAPABILITIES),

--- a/lib/server/openai-native-ungrounded-agent.ts
+++ b/lib/server/openai-native-ungrounded-agent.ts
@@ -121,12 +121,12 @@ function getOpenAIClient() {
 function buildSystemPrompt(): string {
   return [
     "You are the ungrounded raw AI agent for a supply-chain comparison demo.",
-    "You are not allowed to claim Supplie snapshot access, live ERP access, or any other grounded Supplie system.",
+    "You are not allowed to claim Annona snapshot access, live ERP access, or any other grounded Annona system.",
     "When using OpenAI native tools, say exactly which tool actually ran in this response.",
     "Use web search for current external information.",
     "Use bundled file workflows only for the static demo files listed below. They are not arbitrary local filesystem access and they are not user uploads.",
     "Use the code interpreter when calculation or structured data analysis would help.",
-    "If the question needs Supplie-specific live data or grounded Supplie snapshot data, say that this raw panel does not have it.",
+    "If the question needs Annona-specific live data or grounded Annona snapshot data, say that this raw panel does not have it.",
     "",
     "Bundled demo files available through OpenAI file workflows:",
     ...RAW_AGENT_FILES.map(

--- a/lib/server/playwright-mock-chat.ts
+++ b/lib/server/playwright-mock-chat.ts
@@ -31,7 +31,7 @@ export function createPlaywrightMockChatResponse({
   const normalizedPrompt = prompt.trim() || "No prompt provided.";
   const responseText =
     agentMode === "grounded"
-      ? `Grounded mock response: the Supplie snapshot points to Suspension King as the main source of margin leakage for "${normalizedPrompt}".`
+      ? `Grounded mock response: the Annona snapshot points to Suspension King as the main source of margin leakage for "${normalizedPrompt}".`
       : `Ungrounded mock response: without grounded data I can only hypothesize about "${normalizedPrompt}" based on general reasoning.`;
 
   const stream = new ReadableStream({

--- a/scripts/run-visual-review.mjs
+++ b/scripts/run-visual-review.mjs
@@ -306,7 +306,7 @@ async function runOpenAIReview({ rubricRaw, manifest, screenshots }) {
     {
       type: "input_text",
       text: [
-        "Review the supplied Supplie demo screenshots against the PRD/demo-plan rubric.",
+        "Review the supplied Annona demo screenshots against the PRD/demo-plan rubric.",
         "Fail the review if any required state or automatic failure condition is violated.",
         "Base the answer only on what is visibly present in the screenshots and the supplied rubric.",
         "",

--- a/tests/e2e/visual-review.spec.ts
+++ b/tests/e2e/visual-review.spec.ts
@@ -113,7 +113,7 @@ test("captures deterministic screenshots for PRD-based visual review", async ({
       page,
       "03-post-prompt-grounded-response.png",
       "post-prompt-response",
-      "Both panels show the same user prompt; the grounded panel also shows a Supplie snapshot tool call and the Suspension King finding.",
+      "Both panels show the same user prompt; the grounded panel also shows an Annona snapshot tool call and the Suspension King finding.",
     ),
   );
 


### PR DESCRIPTION
## Summary
- apply the Annona rebrand across the active demo UI and metadata
- update grounded/raw panel descriptions and generated demo copy to reference Annona where intended
- refresh the active README, visual-review rubric, and related test/support text for the rebrand

## Validation
- npm run lint
- npm run typecheck
- npm test
- DEMO_PASSWORD=test OPENAI_API_KEY=test npm run build
- npx playwright test tests/e2e/demo-flow.spec.ts tests/e2e/visual-review.spec.ts

Closes #23