### PR TITLE
Fix shared native bundle for order-margin scenario

### DIFF
--- a/data/openai-native/demo_order_margin_reference.md
+++ b/data/openai-native/demo_order_margin_reference.md
@@ -1,0 +1,17 @@
+# Demo Order Margin Reference
+
+Use `demo_order_margin_snapshot.csv` for the Suspension King order-margin scenario.
+
+Net margin formula:
+
+`net_margin = revenue - cogs - freight - rebates`
+
+For the bundled three-order Suspension King sample:
+
+- revenue = 43,940
+- cogs = 31,480
+- freight = 3,080
+- rebates = 1,390
+- net_margin = 7,990
+
+These are static bundled demo files for the shared OpenAI-native baseline. They are not live ERP data.

--- a/data/openai-native/demo_order_margin_snapshot.csv
+++ b/data/openai-native/demo_order_margin_snapshot.csv
@@ -1,0 +1,4 @@
+order_id,booked_at,customer,revenue,cogs,freight,rebates
+SK-240317-01,2026-03-17,Suspension King,18420,11980,920,460
+SK-240319-02,2026-03-19,Suspension King,14280,10140,1180,520
+SK-240321-03,2026-03-21,Suspension King,11240,9360,980,410

--- a/docs/demo-acceptance.md
+++ b/docs/demo-acceptance.md
@@ -26,7 +26,8 @@ Expected grounded result:
 Expected left/raw behavior:
 
 - Must not pretend to have grounded operational access it does not have
-- Should answer honestly from the shared baseline
+- Should answer from the shared bundled baseline when the prompt is solvable from those bundled files
+- For the Suspension King margin scenario, should attempt the calculation from the bundled order snapshot/reference files
 
 ## Done Criteria
 

--- a/lib/server/openai-native-bundle.test.ts
+++ b/lib/server/openai-native-bundle.test.ts
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+// @ts-expect-error TypeScript does not allow TS extensions without allowImportingTsExtensions.
+import { ANNONA_DEMO_SNAPSHOT } from "./annona-grounded-tools.ts";
+// @ts-expect-error TypeScript does not allow TS extensions without allowImportingTsExtensions.
+import { SHARED_OPENAI_NATIVE_FILES } from "./openai-native-bundle.ts";
+
+interface CsvOrderRow {
+  order_id: string;
+  booked_at: string;
+  customer: string;
+  revenue: number;
+  cogs: number;
+  freight: number;
+  rebates: number;
+}
+
+function parseOrderSnapshotCsv(contents: string): CsvOrderRow[] {
+  const [headerLine, ...rows] = contents.trim().split("\n");
+
+  assert.equal(
+    headerLine,
+    "order_id,booked_at,customer,revenue,cogs,freight,rebates",
+  );
+
+  return rows.map((row) => {
+    const [order_id, booked_at, customer, revenue, cogs, freight, rebates] =
+      row.split(",");
+
+    return {
+      order_id,
+      booked_at,
+      customer,
+      revenue: Number(revenue),
+      cogs: Number(cogs),
+      freight: Number(freight),
+      rebates: Number(rebates),
+    };
+  });
+}
+
+test("shared OpenAI-native bundle includes the bundled order-margin files", () => {
+  assert.deepEqual(
+    SHARED_OPENAI_NATIVE_FILES.map((file) => file.fileName),
+    [
+      "capability-baseline-notes.md",
+      "global_freight_benchmarks.csv",
+      "demo_order_margin_snapshot.csv",
+      "demo_order_margin_reference.md",
+    ],
+  );
+
+  for (const file of SHARED_OPENAI_NATIVE_FILES) {
+    assert.ok(
+      existsSync(file.absolutePath),
+      `Expected bundled file to exist: ${file.absolutePath}`,
+    );
+  }
+});
+
+test("shared order-margin CSV stays aligned with the Annona demo snapshot rows", () => {
+  const csvFile = SHARED_OPENAI_NATIVE_FILES.find(
+    (file) => file.fileName === "demo_order_margin_snapshot.csv",
+  );
+
+  assert.ok(csvFile, "Expected demo order margin snapshot CSV in bundle");
+
+  const csvOrders = parseOrderSnapshotCsv(readFileSync(csvFile.absolutePath, "utf8"));
+
+  assert.deepEqual(csvOrders, ANNONA_DEMO_SNAPSHOT.orders);
+});
+
+test("raw OpenAI-native prompt tells the model to calculate from the shared bundle", () => {
+  const source = readFileSync(
+    new URL("./openai-native-ungrounded-agent.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    source,
+    /attempt the calculation before saying data is missing/i,
+  );
+  assert.match(source, /SHARED_OPENAI_NATIVE_FILES\.map/);
+  assert.doesNotMatch(
+    source,
+    /Annona-specific live data or grounded Annona snapshot data, say that this raw panel does not have it/,
+  );
+});
+
+test("grounded OpenAI-native prompt retains the same shared bundle plus Annona-only extras", () => {
+  const source = readFileSync(
+    new URL("./openai-native-grounded-agent.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    source,
+    /same native OpenAI web, file, and code tooling baseline as the raw panel, plus Annona-specific tools, calculators, and demo datasets/i,
+  );
+  assert.match(source, /SHARED_OPENAI_NATIVE_FILES\.map/);
+  assert.match(source, /annonaOpenAIFunctionTools/);
+});

--- a/lib/server/openai-native-bundle.ts
+++ b/lib/server/openai-native-bundle.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import OpenAI, { toFile } from "openai";
 
-const SHARED_BUNDLE_ID = "supplie-demo-openai-native-shared-bundle-v1";
+const SHARED_BUNDLE_ID = "supplie-demo-openai-native-shared-bundle-v2";
 const SHARED_VECTOR_STORE_NAME = "supplie-demo-openai-native-reference-files";
 
 export const SHARED_OPENAI_NATIVE_FILES = [
@@ -27,6 +27,28 @@ export const SHARED_OPENAI_NATIVE_FILES = [
     ),
     description:
       "A shared illustrative freight benchmark CSV available to both panels through native OpenAI file and code workflows.",
+  },
+  {
+    fileName: "demo_order_margin_snapshot.csv",
+    absolutePath: path.join(
+      /* turbopackIgnore: true */ process.cwd(),
+      "data",
+      "openai-native",
+      "demo_order_margin_snapshot.csv",
+    ),
+    description:
+      "Static demo order snapshot rows for the Suspension King margin scenario, including revenue, COGS, freight, and rebates.",
+  },
+  {
+    fileName: "demo_order_margin_reference.md",
+    absolutePath: path.join(
+      /* turbopackIgnore: true */ process.cwd(),
+      "data",
+      "openai-native",
+      "demo_order_margin_reference.md",
+    ),
+    description:
+      "Reference notes for calculating demo net margin from the bundled order snapshot CSV.",
   },
 ] as const;
 
@@ -93,7 +115,10 @@ async function findExistingBundle(
   });
   const fileIds = filesPage.data.map((file) => file.id);
 
-  if (fileIds.length === 0) {
+  if (
+    fileIds.length === 0 ||
+    fileIds.length !== SHARED_OPENAI_NATIVE_FILES.length
+  ) {
     return null;
   }
 

--- a/lib/server/openai-native-grounded-agent.ts
+++ b/lib/server/openai-native-grounded-agent.ts
@@ -10,7 +10,11 @@ import type {
   DemoAgent,
   DemoAgentEvent,
 } from "./demo-agent-runner";
-import { getOpenAIClient, prepareOpenAIBundle, SHARED_OPENAI_NATIVE_FILES } from "./openai-native-bundle";
+import {
+  getOpenAIClient,
+  prepareOpenAIBundle,
+  SHARED_OPENAI_NATIVE_FILES,
+} from "./openai-native-bundle";
 import {
   getResponseFunctionCalls,
   parseResponseFunctionArguments,
@@ -21,12 +25,13 @@ import {
 
 const MAX_TOOL_TURNS = 6;
 
-function buildSystemPrompt(): string {
+export function buildOpenAINativeGroundedSystemPrompt(): string {
   return [
     "You are the grounded Annona agent for a supply-chain comparison demo.",
     "You have the same native OpenAI web, file, and code tooling baseline as the raw panel, plus Annona-specific tools, calculators, and demo datasets.",
     "Always prefer Annona tools for questions about snapshot numbers, rankings, order details, stock risk, margin leakage, or Annona-specific calculations.",
     "Use OpenAI native tools when outside research, file inspection, or sandboxed computation would help, and say explicitly whether each tool used was an OpenAI native tool or an Annona tool.",
+    "For numeric questions over bundled CSVs, prefer using the code interpreter on the bundled data instead of only paraphrasing reference notes.",
     "Your Annona data is limited to the bundled Annona demo snapshot. It is not live production data.",
     "Do not claim live ERP or warehouse access.",
     "",
@@ -57,7 +62,7 @@ export function createOpenAINativeGroundedAgent(model: string): DemoAgent {
             {
               type: "message",
               role: "developer",
-              content: buildSystemPrompt(),
+              content: buildOpenAINativeGroundedSystemPrompt(),
             },
             ...toInputMessages(messages),
           ],

--- a/lib/server/openai-native-ungrounded-agent.ts
+++ b/lib/server/openai-native-ungrounded-agent.ts
@@ -16,7 +16,7 @@ import {
   type ResponseCreateResult,
 } from "./openai-responses-utils";
 
-function buildSystemPrompt(): string {
+export function buildOpenAINativeUngroundedSystemPrompt(): string {
   return [
     "You are the ungrounded raw AI agent for a supply-chain comparison demo.",
     "You are not allowed to claim Annona snapshot access, live ERP access, or any other grounded Annona system.",
@@ -24,7 +24,9 @@ function buildSystemPrompt(): string {
     "Use web search for current external information.",
     "Use bundled file workflows only for the static demo files listed below. They are not arbitrary local filesystem access and they are not user uploads.",
     "Use the code interpreter when calculation or structured data analysis would help.",
-    "If the question needs Annona-specific live data or grounded Annona snapshot data, say that this raw panel does not have it.",
+    "For numeric questions over bundled CSVs, prefer using the code interpreter on the bundled data instead of only paraphrasing reference notes.",
+    "If a question can be answered from the shared bundled demo files, inspect those files and attempt the calculation before saying data is missing.",
+    "If the question needs Annona-only tools, hidden grounded snapshot data beyond the shared bundle, or live operational access, say that this raw panel does not have it.",
     "",
     "Bundled demo files available through OpenAI file workflows:",
     ...SHARED_OPENAI_NATIVE_FILES.map(
@@ -48,7 +50,7 @@ export function createOpenAINativeUngroundedAgent(model: string): DemoAgent {
             {
               type: "message",
               role: "developer",
-              content: buildSystemPrompt(),
+              content: buildOpenAINativeUngroundedSystemPrompt(),
             },
             ...toInputMessages(messages),
           ],

--- a/tests/fixtures/demo-scenarios.json
+++ b/tests/fixtures/demo-scenarios.json
@@ -11,8 +11,12 @@
         "notes": "Grounded Annona panel should return the known snapshot result"
       },
       "expectedRaw": {
+        "mustContainOneOf": [
+          "7,990",
+          "7990"
+        ],
         "mustNotPretendGroundedAccess": true,
-        "notes": "Raw panel should respond honestly from the shared baseline"
+        "notes": "Raw panel should attempt the calculation from the shared bundled files while staying honest about lacking Annona-only grounded access"
       }
     }
   ]


### PR DESCRIPTION
## Summary
- add shared bundled order-margin CSV/reference files for the Suspension King scenario
- update the shared OpenAI-native baseline and prompt guidance so both panels can use those files while Annona remains the right-panel-only superset
- add tests/spec updates for the shared bundle and raw-panel behavior

## Validation
- npm test
- npm run typecheck
- npm run build
- live local POST to /api/chat (raw OpenAI panel) confirming bundled-file retrieval and a 7,990 answer for the Suspension King margin prompt

Closes #27