### PR TITLE
Fix #29: refresh demo UI with Annona marble theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,27 +1,34 @@
 @import "tailwindcss";
 
 :root {
-  --bg-primary: #08121b;
-  --bg-shell: rgba(7, 12, 18, 0.84);
-  --bg-shell-strong: rgba(10, 16, 24, 0.96);
-  --bg-secondary: #101922;
-  --bg-tertiary: #172231;
-  --bg-amber-panel: linear-gradient(180deg, #1d1710 0%, #100d09 100%);
-  --bg-teal-panel: linear-gradient(180deg, #0f1d1f 0%, #081215 100%);
+  --bg-primary: #f5f5f0;
+  --bg-shell: rgba(255, 255, 255, 0.82);
+  --bg-shell-strong: rgba(255, 255, 255, 0.94);
+  --bg-secondary: #ffffff;
+  --bg-tertiary: #f0fbff;
+  --bg-raw-panel: linear-gradient(180deg, #ffffff 0%, #fbf6ed 100%);
+  --bg-grounded-panel: linear-gradient(180deg, #ffffff 0%, #f0fbff 100%);
 
-  --text-primary: #f3f7fb;
-  --text-secondary: #b1bfd1;
-  --text-muted: #738298;
+  --text-primary: #1c1c1a;
+  --text-secondary: #3d3d3a;
+  --text-muted: #737370;
 
-  --border-subtle: rgba(255, 255, 255, 0.08);
-  --border-strong: rgba(255, 255, 255, 0.14);
-  --shadow-panel: 0 24px 80px rgba(2, 6, 14, 0.42);
+  --border-subtle: rgba(28, 28, 26, 0.08);
+  --border-strong: rgba(0, 95, 119, 0.16);
+  --shadow-panel: 0 24px 72px rgba(28, 28, 26, 0.08);
 
-  --accent-amber: #f3a63b;
-  --accent-amber-soft: rgba(243, 166, 59, 0.16);
-  --accent-teal: #2ed3c4;
-  --accent-teal-soft: rgba(46, 211, 196, 0.16);
-  --accent-sky: #72a8ff;
+  --accent-blue: #00d2ff;
+  --accent-blue-soft: rgba(0, 210, 255, 0.12);
+  --accent-blue-strong: rgba(0, 210, 255, 0.22);
+  --accent-raw: #c7862f;
+  --accent-raw-soft: rgba(199, 134, 47, 0.12);
+  --accent-teal: #005f77;
+  --accent-teal-soft: rgba(0, 95, 119, 0.1);
+  --rule: #ddddd6;
+
+  --font-heading: "Aeonik", "Avenir Next", "Helvetica Neue", sans-serif;
+  --font-body: "Inter", "Avenir Next", "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", "SFMono-Regular", "SF Mono", monospace;
 }
 
 @keyframes slide-in {
@@ -93,15 +100,15 @@ body {
   margin: 0;
   padding: 0;
   background:
-    radial-gradient(circle at top left, rgba(46, 211, 196, 0.12), transparent 28%),
-    radial-gradient(circle at top right, rgba(114, 168, 255, 0.18), transparent 26%),
-    linear-gradient(180deg, #061018 0%, #08111a 42%, #070c12 100%);
+    radial-gradient(circle at top right, rgba(0, 210, 255, 0.14), transparent 24%),
+    radial-gradient(circle at top left, rgba(0, 95, 119, 0.08), transparent 26%),
+    linear-gradient(180deg, #f9f9f5 0%, #f5f5f0 48%, #eef9fd 100%);
   color: var(--text-primary);
-  font-family: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
+  font-family: var(--font-body);
 }
 
 body::selection {
-  background: rgba(46, 211, 196, 0.3);
+  background: rgba(0, 210, 255, 0.24);
 }
 
 a {
@@ -114,10 +121,10 @@ a {
 }
 
 ::-webkit-scrollbar-track {
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(28, 28, 26, 0.04);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(115, 130, 152, 0.45);
+  background: rgba(61, 61, 58, 0.24);
   border-radius: 999px;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -382,23 +382,52 @@ export default function Home() {
       className="min-h-screen px-4 py-4 sm:px-5"
       style={{
         background: "transparent",
-        fontFamily: '"Space Grotesk", "Avenir Next", "Segoe UI", sans-serif',
+        fontFamily: 'var(--font-body)',
       }}
     >
-      <div className="mx-auto flex min-h-[calc(100vh-2rem)] w-full max-w-[1540px] flex-col rounded-[32px] border border-white/10 bg-[var(--bg-shell)] p-3 shadow-[0_32px_120px_rgba(2,6,14,0.5)] backdrop-blur-xl">
-        <div className="rounded-[28px] border border-white/8 bg-[linear-gradient(180deg,rgba(11,17,25,0.92),rgba(8,13,20,0.92))] px-5 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+      <div className="mx-auto flex min-h-[calc(100vh-2rem)] w-full max-w-[1540px] flex-col rounded-[32px] border p-3 backdrop-blur-xl"
+        style={{
+          borderColor: "var(--border-subtle)",
+          background: "var(--bg-shell)",
+          boxShadow:
+            "0 28px 100px rgba(28, 28, 26, 0.1), inset 0 1px 0 rgba(255,255,255,0.72)",
+        }}
+      >
+        <div
+          className="rounded-[28px] px-5 py-4"
+          style={{
+            border: "1px solid rgba(221, 221, 214, 0.9)",
+            background:
+              "linear-gradient(180deg, rgba(255,255,255,0.94), rgba(245,245,240,0.82))",
+            boxShadow: "inset 0 1px 0 rgba(255,255,255,0.72)",
+          }}
+        >
           <div className="flex flex-wrap items-center gap-4">
             <div className="flex min-w-0 items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-teal-300/20 bg-[linear-gradient(135deg,rgba(20,184,166,0.22),rgba(56,189,248,0.18))] shadow-[0_12px_30px_rgba(20,184,166,0.18)]">
-                <div className="h-3 w-3 rounded-full bg-teal-300" />
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-2xl"
+                style={{
+                  border: "1px solid rgba(0, 210, 255, 0.18)",
+                  background:
+                    "linear-gradient(135deg, rgba(240, 251, 255, 0.98), rgba(255,255,255,0.92))",
+                  boxShadow: "0 14px 28px rgba(0, 210, 255, 0.12)",
+                }}
+              >
+                <div
+                  className="h-3 w-3 rounded-full"
+                  style={{ background: "var(--accent-blue)" }}
+                />
               </div>
               <div>
                 <div className="flex flex-wrap items-center gap-2">
                   <span
                     className="text-sm font-semibold"
-                    style={{ color: "var(--text-primary)" }}
+                    style={{
+                      color: "var(--text-primary)",
+                      fontFamily: "var(--font-heading)",
+                    }}
                   >
-                    Annona
+                    Annona<span style={{ color: "var(--accent-blue)" }}>.</span>
                   </span>
                   <span
                     className="text-[11px] tracking-[0.24em]"
@@ -407,7 +436,10 @@ export default function Home() {
                     Grounding Demo
                   </span>
                 </div>
-                <div className="text-sm text-slate-400">
+                <div
+                  className="text-sm"
+                  style={{ color: "var(--text-secondary)" }}
+                >
                   Demo-quality side-by-side review of raw reasoning vs grounded
                   Annona output.
                 </div>
@@ -417,7 +449,13 @@ export default function Home() {
               <ModelPicker value={model} onChange={handleModelChange} />
               <button
                 onClick={handleClear}
-                className="rounded-xl border border-white/10 bg-[rgba(255,255,255,0.04)] px-3 py-2 text-xs text-slate-300 transition-all hover:border-white/20 hover:text-white"
+                className="rounded-xl border px-3 py-2 text-xs transition-all hover:-translate-y-0.5"
+                style={{
+                  borderColor: "rgba(28, 28, 26, 0.1)",
+                  background: "rgba(255,255,255,0.9)",
+                  color: "var(--text-secondary)",
+                  boxShadow: "0 8px 20px rgba(28, 28, 26, 0.05)",
+                }}
               >
                 Clear
               </button>
@@ -429,12 +467,24 @@ export default function Home() {
               onPrompt={handlePrompt}
               disabled={ungroundedChat.isLoading || groundedChat.isLoading}
             />
-
-            <div className="rounded-[24px] border border-white/8 bg-[linear-gradient(180deg,rgba(9,14,22,0.86),rgba(9,13,20,0.74))] px-4 py-4">
-              <div className="text-[11px] uppercase tracking-[0.22em] text-slate-500">
+            <div
+              className="rounded-[24px] px-4 py-4"
+              style={{
+                border: "1px solid rgba(221, 221, 214, 0.95)",
+                background:
+                  "linear-gradient(180deg, rgba(255,255,255,0.98), rgba(240,251,255,0.72))",
+              }}
+            >
+              <div
+                className="text-[11px] uppercase tracking-[0.22em]"
+                style={{ color: "var(--text-muted)" }}
+              >
                 Live Comparison
               </div>
-              <div className="mt-2 text-sm leading-6 text-slate-100">
+              <div
+                className="mt-2 text-sm leading-6"
+                style={{ color: "var(--text-primary)" }}
+              >
                 Left panel stays raw on {ungroundedPanel.backendLabel}. Right
                 panel runs {groundedPanel.backendLabel}
                 {comparisonMessage.sharedNativeToolLabels.length > 0
@@ -442,14 +492,31 @@ export default function Home() {
                   : " as the Annona-specific superset, while native provider web, sandbox, and file tools are unavailable in this deployment."}
               </div>
               <div className="mt-3 flex flex-wrap gap-2 text-xs">
-                <span className="rounded-full border border-[rgba(243,166,59,0.18)] bg-[rgba(243,166,59,0.08)] px-3 py-1 text-amber-200">
+                <span
+                  className="rounded-full border px-3 py-1"
+                  style={{
+                    borderColor: "rgba(199, 134, 47, 0.2)",
+                    background: "rgba(199, 134, 47, 0.08)",
+                    color: "#8a5618",
+                  }}
+                >
                   Raw: {comparisonMessage.ungroundedCapabilities}
                 </span>
-                <span className="rounded-full border border-[rgba(46,211,196,0.18)] bg-[rgba(46,211,196,0.08)] px-3 py-1 text-teal-200">
+                <span
+                  className="rounded-full border px-3 py-1"
+                  style={{
+                    borderColor: "rgba(0, 210, 255, 0.24)",
+                    background: "rgba(0, 210, 255, 0.08)",
+                    color: "#005f77",
+                  }}
+                >
                   Grounded: {comparisonMessage.groundedCapabilities}
                 </span>
               </div>
-              <div className="mt-3 text-xs leading-5 text-slate-400">
+              <div
+                className="mt-3 text-xs leading-5"
+                style={{ color: "var(--text-muted)" }}
+              >
                 Shared limits: {comparisonMessage.sharedLimitations}
               </div>
             </div>
@@ -462,8 +529,8 @@ export default function Home() {
             title={ungroundedPanel.title}
             badge={ungroundedPanel.badge}
             badgeColor={ungroundedPanel.badgeColor}
-            bgColor="var(--bg-amber-panel)"
-            borderColor="border-amber-300/14"
+            bgColor="var(--bg-raw-panel)"
+            borderColor="rgba(199, 134, 47, 0.18)"
             note={ungroundedPanel.description}
             emptyStateTitle={ungroundedPanel.emptyStateTitle}
             emptyStateDetail={ungroundedPanel.emptyStateDetail}
@@ -477,8 +544,8 @@ export default function Home() {
             title={groundedPanel.title}
             badge={groundedPanel.badge}
             badgeColor={groundedPanel.badgeColor}
-            bgColor="var(--bg-teal-panel)"
-            borderColor="border-teal-300/14"
+            bgColor="var(--bg-grounded-panel)"
+            borderColor="rgba(0, 210, 255, 0.2)"
             note={groundedPanel.description}
             emptyStateTitle={groundedPanel.emptyStateTitle}
             emptyStateDetail={groundedPanel.emptyStateDetail}

--- a/components/ModelPicker.tsx
+++ b/components/ModelPicker.tsx
@@ -43,7 +43,10 @@ export function ModelPicker({ value, onChange }: ModelPickerProps) {
 
   return (
     <div className="flex items-center gap-2">
-      <span className="text-xs uppercase tracking-[0.2em] text-slate-500">
+      <span
+        className="text-xs uppercase tracking-[0.2em]"
+        style={{ color: "var(--text-muted)" }}
+      >
         Model
       </span>
       <div className="relative">
@@ -53,7 +56,13 @@ export function ModelPicker({ value, onChange }: ModelPickerProps) {
             const m = MODELS.find((m) => m.modelId === e.target.value)!;
             onChange(m.modelId, m.provider);
           }}
-          className="cursor-pointer appearance-none rounded-xl border border-white/10 bg-[linear-gradient(180deg,rgba(20,29,42,0.9),rgba(10,15,24,0.9))] py-2 pl-3 pr-8 text-xs text-slate-200 outline-none transition-colors focus:border-teal-400/50"
+          className="cursor-pointer appearance-none rounded-xl border py-2 pl-3 pr-8 text-xs outline-none transition-colors"
+          style={{
+            borderColor: "rgba(28, 28, 26, 0.1)",
+            background:
+              "linear-gradient(180deg, rgba(255,255,255,0.98), rgba(245,245,240,0.92))",
+            color: "var(--text-primary)",
+          }}
         >
           {MODELS.map((m) => (
             <option key={m.modelId} value={m.modelId}>
@@ -66,7 +75,8 @@ export function ModelPicker({ value, onChange }: ModelPickerProps) {
         </select>
         <div className="pointer-events-none absolute inset-y-0 right-2 flex items-center">
           <svg
-            className="h-3 w-3 text-slate-500"
+            className="h-3 w-3"
+            style={{ color: "var(--text-muted)" }}
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"

--- a/components/Panel.tsx
+++ b/components/Panel.tsx
@@ -48,30 +48,44 @@ export function Panel({
 
   const badgeStyles = {
     amber:
-      "border border-[rgba(243,166,59,0.18)] bg-[rgba(243,166,59,0.12)] text-amber-200",
+      "border text-[color:#8a5618]",
     teal:
-      "border border-[rgba(46,211,196,0.18)] bg-[rgba(46,211,196,0.12)] text-teal-200",
+      "border text-[color:#005f77]",
   };
   const accentStyles = {
     amber: {
-      orb: "bg-amber-300/80",
-      ring: "border-[rgba(243,166,59,0.2)] bg-[rgba(243,166,59,0.06)]",
-      note: "from-amber-500/10 to-transparent",
+      orb: "bg-[color:#c7862f]",
+      headerBorder: "rgba(199, 134, 47, 0.18)",
+      badgeBorder: "rgba(199, 134, 47, 0.22)",
+      badgeBg: "rgba(199, 134, 47, 0.1)",
+      ring: "border-[rgba(199,134,47,0.16)] bg-[rgba(255,249,241,0.96)]",
+      noteBorder: "rgba(199, 134, 47, 0.14)",
+      noteBg:
+        "linear-gradient(90deg, rgba(199,134,47,0.08), rgba(255,255,255,0.72))",
       message:
-        "border-[rgba(243,166,59,0.14)] bg-[rgba(243,166,59,0.08)]",
-      userMessage: "border-slate-600/50 bg-[linear-gradient(180deg,rgba(33,44,61,0.92),rgba(25,34,49,0.92))]",
-      retry:
-        "border-[rgba(243,166,59,0.3)] text-amber-200 hover:border-[rgba(243,166,59,0.6)]",
+        "border-[rgba(199,134,47,0.16)] bg-[rgba(255,250,244,0.96)]",
+      userMessage:
+        "border-[rgba(199,134,47,0.12)] bg-[linear-gradient(180deg,rgba(249,244,235,0.98),rgba(244,236,224,0.98))]",
+      retryBorder: "rgba(199, 134, 47, 0.28)",
+      retryText: "#8a5618",
+      indicator: "bg-[color:#c7862f]",
     },
     teal: {
-      orb: "bg-teal-300/80",
-      ring: "border-[rgba(46,211,196,0.2)] bg-[rgba(46,211,196,0.06)]",
-      note: "from-teal-400/10 to-transparent",
+      orb: "bg-[color:#00d2ff]",
+      headerBorder: "rgba(0, 210, 255, 0.18)",
+      badgeBorder: "rgba(0, 210, 255, 0.22)",
+      badgeBg: "rgba(0, 210, 255, 0.1)",
+      ring: "border-[rgba(0,210,255,0.16)] bg-[rgba(240,251,255,0.98)]",
+      noteBorder: "rgba(0, 210, 255, 0.16)",
+      noteBg:
+        "linear-gradient(90deg, rgba(0,210,255,0.08), rgba(255,255,255,0.78))",
       message:
-        "border-[rgba(46,211,196,0.14)] bg-[rgba(46,211,196,0.08)]",
-      userMessage: "border-slate-600/50 bg-[linear-gradient(180deg,rgba(33,44,61,0.92),rgba(25,34,49,0.92))]",
-      retry:
-        "border-[rgba(46,211,196,0.3)] text-teal-200 hover:border-[rgba(46,211,196,0.6)]",
+        "border-[rgba(0,210,255,0.18)] bg-[rgba(240,251,255,0.98)]",
+      userMessage:
+        "border-[rgba(0,95,119,0.12)] bg-[linear-gradient(180deg,rgba(244,252,255,0.98),rgba(232,247,252,0.98))]",
+      retryBorder: "rgba(0, 95, 119, 0.24)",
+      retryText: "#005f77",
+      indicator: "bg-[color:#00d2ff]",
     },
   };
   const accent = accentStyles[badgeColor];
@@ -79,20 +93,27 @@ export function Panel({
   return (
     <div
       data-testid={`panel-${panelId}`}
-      className={`flex h-full flex-col overflow-hidden rounded-[28px] border ${borderColor} shadow-[0_24px_60px_rgba(3,8,16,0.28)]`}
-      style={{ background: bgColor }}
+      className="flex h-full flex-col overflow-hidden rounded-[28px] border shadow-[0_24px_60px_rgba(28,28,26,0.08)]"
+      style={{ background: bgColor, borderColor }}
     >
-      <div className="border-b border-white/8 px-5 py-4">
+      <div className="px-5 py-4" style={{ borderBottom: `1px solid ${accent.headerBorder}` }}>
         <div className="flex items-center gap-3">
           <div className={`h-2.5 w-2.5 rounded-full ${accent.orb} shadow-lg`} />
           <span
             className="text-[15px] font-semibold tracking-[-0.02em]"
-            style={{ color: "var(--text-primary)" }}
+            style={{
+              color: "var(--text-primary)",
+              fontFamily: "var(--font-heading)",
+            }}
           >
             {title}
           </span>
           <span
             className={`rounded-full px-2.5 py-1 text-[11px] uppercase tracking-[0.18em] ${badgeStyles[badgeColor]}`}
+            style={{
+              borderColor: accent.badgeBorder,
+              background: accent.badgeBg,
+            }}
           >
             {badge}
           </span>
@@ -101,7 +122,7 @@ export function Panel({
               {[0, 1, 2].map((i) => (
                 <div
                   key={i}
-                  className={`h-1.5 w-1.5 rounded-full ${badgeColor === "teal" ? "bg-teal-300" : "bg-amber-300"} animate-bounce`}
+                  className={`h-1.5 w-1.5 rounded-full ${accent.indicator} animate-bounce`}
                   style={{ animationDelay: `${i * 150}ms` }}
                 />
               ))}
@@ -109,7 +130,12 @@ export function Panel({
           )}
         </div>
         <span
-          className={`mt-3 block rounded-2xl border border-white/8 bg-gradient-to-r px-4 py-3 text-xs leading-relaxed text-slate-300 ${accent.note}`}
+          className="mt-3 block rounded-2xl border px-4 py-3 text-xs leading-relaxed"
+          style={{
+            borderColor: accent.noteBorder,
+            background: accent.noteBg,
+            color: "var(--text-secondary)",
+          }}
         >
           {note}
         </span>
@@ -147,7 +173,8 @@ export function Panel({
             {msg.role === "user" && (
               <div className="flex justify-end">
                 <div
-                  className={`max-w-xs rounded-2xl border px-4 py-3 text-sm text-slate-100 shadow-[0_12px_30px_rgba(3,8,16,0.22)] ${accent.userMessage}`}
+                  className={`max-w-xs rounded-2xl border px-4 py-3 text-sm shadow-[0_12px_30px_rgba(28,28,26,0.08)] ${accent.userMessage}`}
+                  style={{ color: "var(--text-primary)" }}
                 >
                   {msg.content}
                 </div>
@@ -185,7 +212,10 @@ export function Panel({
                     </div>
                 )}
                 {msg.content && (
-                  <div className="whitespace-pre-wrap text-sm leading-7 text-slate-100">
+                  <div
+                    className="whitespace-pre-wrap text-sm leading-7"
+                    style={{ color: "var(--text-primary)" }}
+                  >
                     {msg.content}
                   </div>
                 )}
@@ -198,20 +228,26 @@ export function Panel({
           <div className="flex items-center gap-2">
             <button
               onClick={onRetry}
-              className={`rounded-full border px-3 py-1 text-xs transition-colors ${accent.retry}`}
+              className="rounded-full border px-3 py-1 text-xs transition-colors"
+              style={{
+                borderColor: accent.retryBorder,
+                color: accent.retryText,
+              }}
             >
               ↺ Retry
             </button>
-            <span className="text-slate-500 text-xs">{error.message}</span>
+            <span className="text-xs" style={{ color: "var(--text-muted)" }}>
+              {error.message}
+            </span>
           </div>
         )}
         {is429 && (
-          <div className="text-slate-400 text-xs">
+          <div className="text-xs" style={{ color: "var(--text-muted)" }}>
             Rate limit exceeded. Retry when the minute window resets.
           </div>
         )}
         {is401 && (
-          <div className="text-slate-400 text-xs">
+          <div className="text-xs" style={{ color: "var(--text-muted)" }}>
             Session expired. Refresh and authenticate again.
           </div>
         )}

--- a/components/PasswordGate.tsx
+++ b/components/PasswordGate.tsx
@@ -51,47 +51,87 @@ export function PasswordGate({ onAuth }: PasswordGateProps) {
       className="fixed inset-0 z-50 overflow-hidden"
       style={{
         background:
-          "radial-gradient(circle at top left, rgba(46, 211, 196, 0.2), transparent 28%), radial-gradient(circle at top right, rgba(243, 166, 59, 0.14), transparent 26%), linear-gradient(180deg, #061018 0%, #070d14 52%, #050a0f 100%)",
+          "radial-gradient(circle at top right, rgba(0, 210, 255, 0.16), transparent 24%), radial-gradient(circle at top left, rgba(0, 95, 119, 0.08), transparent 30%), linear-gradient(180deg, #fafaf6 0%, #f5f5f0 54%, #eef9fd 100%)",
       }}
     >
       <div className="pointer-events-none absolute inset-0">
-        <div className="absolute left-[12%] top-[18%] h-56 w-56 rounded-full bg-teal-400/10 blur-3xl animate-float-slow" />
-        <div className="absolute right-[10%] top-[12%] h-64 w-64 rounded-full bg-sky-400/10 blur-3xl animate-float-slower" />
-        <div className="absolute bottom-[10%] left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-amber-300/10 blur-3xl animate-float-slow" />
+        <div className="absolute left-[12%] top-[18%] h-56 w-56 rounded-full blur-3xl animate-float-slow" style={{ background: "rgba(0, 210, 255, 0.12)" }} />
+        <div className="absolute right-[10%] top-[12%] h-64 w-64 rounded-full blur-3xl animate-float-slower" style={{ background: "rgba(0, 95, 119, 0.08)" }} />
+        <div className="absolute bottom-[10%] left-1/2 h-72 w-72 -translate-x-1/2 rounded-full blur-3xl animate-float-slow" style={{ background: "rgba(240, 251, 255, 0.84)" }} />
       </div>
 
       <div className="relative flex min-h-screen items-stretch justify-center px-4 py-4 sm:px-6 sm:py-6">
-        <div className="relative flex w-full max-w-6xl flex-col overflow-hidden rounded-[34px] border border-white/12 bg-[rgba(6,12,18,0.82)] shadow-[0_30px_120px_rgba(2,6,14,0.55)] backdrop-blur-xl">
+        <div
+          className="relative flex w-full max-w-6xl flex-col overflow-hidden rounded-[34px] border backdrop-blur-xl"
+          style={{
+            borderColor: "rgba(221, 221, 214, 0.9)",
+            background: "rgba(255,255,255,0.76)",
+            boxShadow: "0 30px 120px rgba(28,28,26,0.1)",
+          }}
+        >
           <div className="pointer-events-none absolute inset-0">
-            <div className="absolute inset-x-0 top-0 h-40 bg-[linear-gradient(180deg,rgba(34,211,238,0.12),transparent)]" />
-            <div className="absolute inset-y-0 left-0 w-px bg-white/10" />
-            <div className="absolute inset-y-0 right-0 w-px bg-white/10" />
-            <div className="absolute inset-x-0 bottom-0 h-px bg-white/10" />
+            <div className="absolute inset-x-0 top-0 h-40" style={{ background: "linear-gradient(180deg, rgba(0,210,255,0.1), transparent)" }} />
+            <div className="absolute inset-y-0 left-0 w-px" style={{ background: "rgba(221, 221, 214, 0.9)" }} />
+            <div className="absolute inset-y-0 right-0 w-px" style={{ background: "rgba(221, 221, 214, 0.9)" }} />
+            <div className="absolute inset-x-0 bottom-0 h-px" style={{ background: "rgba(221, 221, 214, 0.9)" }} />
           </div>
 
           <div className="relative flex min-h-[calc(100vh-2rem)] flex-1 flex-col justify-between px-6 py-8 sm:px-10 sm:py-10 lg:px-14 lg:py-12">
-            <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-[rgba(255,255,255,0.05)] px-3 py-1 text-[10px] font-medium uppercase tracking-[0.28em] text-slate-300">
+            <div
+              className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[10px] font-medium uppercase tracking-[0.28em]"
+              style={{
+                borderColor: "rgba(0, 210, 255, 0.18)",
+                background: "rgba(240, 251, 255, 0.82)",
+                color: "var(--text-secondary)",
+              }}
+            >
               Private Preview
             </div>
 
             <div className="flex flex-1 items-center justify-center py-10 lg:py-12">
               <div className="mx-auto flex w-full max-w-3xl flex-col items-center justify-center text-center">
-                <div className="text-4xl font-semibold tracking-[-0.04em] text-slate-50 sm:text-5xl lg:text-6xl">
-                  Annona<span className="text-teal-400">.</span>
+                <div
+                  className="text-4xl font-semibold tracking-[-0.04em] sm:text-5xl lg:text-6xl"
+                  style={{
+                    color: "var(--text-primary)",
+                    fontFamily: "var(--font-heading)",
+                  }}
+                >
+                  Annona<span style={{ color: "var(--accent-blue)" }}>.</span>
                 </div>
-                <div className="mt-3 text-xs tracking-[0.32em] text-slate-400">
+                <div
+                  className="mt-3 text-xs tracking-[0.32em]"
+                  style={{ color: "var(--text-muted)" }}
+                >
                   Grounding Demo
                 </div>
-                <p className="mt-6 max-w-xl text-sm leading-7 text-slate-300 sm:text-base">
+                <p
+                  className="mt-6 max-w-xl text-sm leading-7 sm:text-base"
+                  style={{ color: "var(--text-secondary)" }}
+                >
                   Private Annona grounded demo access. Enter the password to
                   unlock the protected workspace.
                 </p>
-                <div className="mt-8 w-full max-w-xl rounded-[30px] border border-white/12 bg-[linear-gradient(180deg,rgba(9,18,26,0.96),rgba(6,12,18,0.88))] p-6 shadow-[0_24px_80px_rgba(2,6,14,0.42)] sm:p-8">
+                <div
+                  className="mt-8 w-full max-w-xl rounded-[30px] border p-6 sm:p-8"
+                  style={{
+                    borderColor: "rgba(221, 221, 214, 0.95)",
+                    background:
+                      "linear-gradient(180deg, rgba(255,255,255,0.98), rgba(240,251,255,0.82))",
+                    boxShadow: "0 24px 80px rgba(28,28,26,0.08)",
+                  }}
+                >
                   <div className="mb-6 text-center">
-                    <div className="text-[11px] uppercase tracking-[0.26em] text-slate-500">
+                    <div
+                      className="text-[11px] uppercase tracking-[0.26em]"
+                      style={{ color: "var(--text-muted)" }}
+                    >
                       Invite-only access
                     </div>
-                    <p className="mt-3 text-sm leading-6 text-slate-300">
+                    <p
+                      className="mt-3 text-sm leading-6"
+                      style={{ color: "var(--text-secondary)" }}
+                    >
                       Enter the demo password to unlock the protected
                       workspace.
                     </p>
@@ -101,7 +141,13 @@ export function PasswordGate({ onAuth }: PasswordGateProps) {
                     onSubmit={handleSubmit}
                     className={`space-y-4 ${shake ? "animate-shake" : ""}`}
                   >
-                    <div className="rounded-2xl border border-white/10 bg-[rgba(255,255,255,0.04)] p-3">
+                    <div
+                      className="rounded-2xl border p-3"
+                      style={{
+                        borderColor: "rgba(221, 221, 214, 0.95)",
+                        background: "rgba(255,255,255,0.82)",
+                      }}
+                    >
                       <input
                         data-testid="password-input"
                         ref={inputRef}
@@ -109,7 +155,12 @@ export function PasswordGate({ onAuth }: PasswordGateProps) {
                         value={password}
                         onChange={(e) => setPassword(e.target.value)}
                         placeholder="Enter demo password"
-                        className="w-full rounded-[14px] border border-white/10 bg-slate-950/60 px-4 py-4 text-center text-sm tracking-[0.26em] text-slate-100 outline-none transition-colors placeholder:text-slate-500 focus:border-teal-400/50 focus:bg-slate-950/80"
+                        className="w-full rounded-[14px] border px-4 py-4 text-center text-sm tracking-[0.26em] outline-none transition-colors"
+                        style={{
+                          borderColor: "rgba(0, 95, 119, 0.12)",
+                          background: "rgba(245,245,240,0.96)",
+                          color: "var(--text-primary)",
+                        }}
                         autoComplete="current-password"
                       />
                     </div>
@@ -117,14 +168,25 @@ export function PasswordGate({ onAuth }: PasswordGateProps) {
                       data-testid="password-submit"
                       type="submit"
                       disabled={loading || !password.trim()}
-                      className="w-full rounded-2xl border border-teal-300/20 bg-[linear-gradient(135deg,rgba(16,185,166,0.9),rgba(34,211,238,0.72))] py-4 text-sm font-semibold text-white shadow-[0_16px_40px_rgba(20,184,166,0.28)] transition-all hover:-translate-y-0.5 hover:shadow-[0_18px_48px_rgba(20,184,166,0.34)] disabled:cursor-not-allowed disabled:opacity-40"
+                      className="w-full rounded-2xl border py-4 text-sm font-semibold text-white transition-all hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-40"
+                      style={{
+                        borderColor: "rgba(0, 210, 255, 0.18)",
+                        background:
+                          "linear-gradient(135deg, rgba(0, 95, 119, 0.92), rgba(0, 210, 255, 0.86))",
+                        boxShadow: "0 16px 40px rgba(0, 95, 119, 0.18)",
+                      }}
                     >
                       {loading ? "Checking..." : "Enter"}
                     </button>
                     {error && (
                       <div
                         data-testid="password-error"
-                        className="rounded-2xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-center text-sm text-red-300"
+                        className="rounded-2xl border px-4 py-3 text-center text-sm"
+                        style={{
+                          borderColor: "rgba(185, 28, 28, 0.18)",
+                          background: "rgba(254, 242, 242, 0.92)",
+                          color: "#b91c1c",
+                        }}
                       >
                         {error}
                       </div>
@@ -134,7 +196,10 @@ export function PasswordGate({ onAuth }: PasswordGateProps) {
               </div>
             </div>
 
-            <div className="flex items-center justify-between gap-4 text-[11px] uppercase tracking-[0.18em] text-slate-500">
+            <div
+              className="flex items-center justify-between gap-4 text-[11px] uppercase tracking-[0.18em]"
+              style={{ color: "var(--text-muted)" }}
+            >
               <span>Invite-only preview</span>
               <span>Protected workspace remains hidden until auth</span>
             </div>

--- a/components/PromptButtons.tsx
+++ b/components/PromptButtons.tsx
@@ -16,12 +16,23 @@ const PROMPTS = [
 
 export function PromptButtons({ onPrompt, disabled }: PromptButtonsProps) {
   return (
-    <div className="rounded-[24px] border border-white/8 bg-white/4 px-3 py-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+    <div
+      className="rounded-[24px] px-3 py-3"
+      style={{
+        border: "1px solid rgba(221, 221, 214, 0.95)",
+        background:
+          "linear-gradient(180deg, rgba(255,255,255,0.96), rgba(245,245,240,0.82))",
+        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.72)",
+      }}
+    >
       <div className="mb-2 flex items-center justify-between gap-3 px-2">
-        <div className="text-[11px] uppercase tracking-[0.22em] text-slate-500">
+        <div
+          className="text-[11px] uppercase tracking-[0.22em]"
+          style={{ color: "var(--text-muted)" }}
+        >
           Demo prompts
         </div>
-        <div className="text-[11px] text-slate-500">
+        <div className="text-[11px]" style={{ color: "var(--text-muted)" }}>
           One click mirrors the same prompt into both panels
         </div>
       </div>
@@ -31,7 +42,14 @@ export function PromptButtons({ onPrompt, disabled }: PromptButtonsProps) {
             key={i}
             onClick={() => onPrompt(prompt)}
             disabled={disabled}
-            className="min-w-[260px] flex-1 rounded-full border border-slate-700/50 bg-[linear-gradient(180deg,rgba(20,29,42,0.86),rgba(13,19,29,0.86))] px-4 py-2.5 text-center text-xs leading-tight text-slate-200 transition-all hover:-translate-y-0.5 hover:border-slate-500/70 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+            className="min-w-[260px] flex-1 rounded-full border px-4 py-2.5 text-center text-xs leading-tight transition-all hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-50"
+            style={{
+              borderColor: "rgba(0, 95, 119, 0.12)",
+              background:
+                "linear-gradient(180deg, rgba(255,255,255,0.98), rgba(240,251,255,0.9))",
+              color: "var(--text-secondary)",
+              boxShadow: "0 10px 24px rgba(0, 95, 119, 0.06)",
+            }}
           >
             {prompt}
           </button>

--- a/components/ToolCallCard.tsx
+++ b/components/ToolCallCard.tsx
@@ -25,18 +25,18 @@ export function ToolCallCard({
       ? {
           label: "OpenAI native",
           className:
-            "border-sky-400/20 bg-sky-400/10 text-sky-200",
+            "border-[rgba(0,210,255,0.16)] bg-[rgba(0,210,255,0.08)] text-[color:#005f77]",
         }
       : toolName.startsWith("annona_")
         ? {
             label: "Annona tool",
             className:
-              "border-emerald-400/20 bg-emerald-400/10 text-emerald-200",
+              "border-[rgba(0,95,119,0.16)] bg-[rgba(0,95,119,0.08)] text-[color:#005f77]",
           }
         : {
             label: "Demo tool",
             className:
-              "border-white/10 bg-white/5 text-slate-300",
+              "border-[rgba(28,28,26,0.08)] bg-[rgba(255,255,255,0.82)] text-[color:var(--text-secondary)]",
           };
 
   const formatValue = (v: unknown): string => {
@@ -81,22 +81,22 @@ export function ToolCallCard({
 
   return (
     <div
-      className={`mb-2 overflow-hidden rounded-2xl border ${hasError ? "border-red-500/25 bg-red-500/10" : "border-teal-400/20 bg-[linear-gradient(180deg,rgba(11,42,43,0.42),rgba(5,18,22,0.55))]"} animate-slide-in shadow-[0_12px_32px_rgba(0,0,0,0.18)]`}
+      className={`mb-2 overflow-hidden rounded-2xl border ${hasError ? "border-red-500/25 bg-red-500/10" : "border-[rgba(0,95,119,0.12)] bg-[linear-gradient(180deg,rgba(255,255,255,0.98),rgba(240,251,255,0.94))]"} animate-slide-in shadow-[0_12px_32px_rgba(28,28,26,0.06)]`}
       style={{ animationDelay: `${index * 50}ms` }}
     >
       <button
         onClick={() => setExpanded(!expanded)}
-        className="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-white/4"
+        className="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-[rgba(0,210,255,0.04)]"
       >
         {expanded ? (
-          <ChevronDown className="h-3 w-3 flex-shrink-0 text-teal-300" />
+          <ChevronDown className="h-3 w-3 flex-shrink-0 text-[color:#00d2ff]" />
         ) : (
-          <ChevronRight className="h-3 w-3 flex-shrink-0 text-teal-300" />
+          <ChevronRight className="h-3 w-3 flex-shrink-0 text-[color:#00d2ff]" />
         )}
         {hasError && (
           <AlertTriangle className="h-3 w-3 flex-shrink-0 text-red-400" />
         )}
-        <span className="rounded-full border border-white/8 bg-white/5 px-2 py-0.5 font-mono text-[11px] font-semibold text-teal-200">
+        <span className="rounded-full border border-[rgba(0,95,119,0.08)] bg-[rgba(255,255,255,0.82)] px-2 py-0.5 font-mono text-[11px] font-semibold text-[color:#005f77]">
           {toolName}
         </span>
         <span
@@ -105,7 +105,7 @@ export function ToolCallCard({
           {toolSource.label}
         </span>
         <span
-          className={`ml-auto font-mono text-[11px] ${hasError ? "text-red-300" : "text-slate-400"}`}
+          className={`ml-auto font-mono text-[11px] ${hasError ? "text-red-500" : "text-[color:var(--text-muted)]"}`}
         >
           {getResultSummary()}
         </span>
@@ -114,20 +114,20 @@ export function ToolCallCard({
       {expanded && (
         <div className="space-y-3 px-4 pb-4">
           <div>
-            <div className="mb-1 text-[11px] uppercase tracking-[0.18em] text-slate-500">
+            <div className="mb-1 text-[11px] uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
               Inputs
             </div>
-            <pre className="overflow-x-auto whitespace-pre-wrap rounded-xl border border-white/6 bg-black/25 p-3 font-mono text-xs text-slate-300">
+            <pre className="overflow-x-auto whitespace-pre-wrap rounded-xl border border-[rgba(0,95,119,0.08)] bg-[rgba(255,255,255,0.82)] p-3 font-mono text-xs text-[color:var(--text-secondary)]">
               {formatValue(args)}
             </pre>
           </div>
           {result !== undefined && (
             <div>
-              <div className="mb-1 text-[11px] uppercase tracking-[0.18em] text-slate-500">
+              <div className="mb-1 text-[11px] uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
                 Result
               </div>
               <pre
-                className={`max-h-48 overflow-x-auto whitespace-pre-wrap rounded-xl border border-white/6 bg-black/25 p-3 font-mono text-xs ${hasError ? "text-red-200" : "text-teal-100"}`}
+                className={`max-h-48 overflow-x-auto whitespace-pre-wrap rounded-xl border border-[rgba(0,95,119,0.08)] bg-[rgba(255,255,255,0.82)] p-3 font-mono text-xs ${hasError ? "text-red-600" : "text-[color:var(--text-primary)]"}`}
               >
                 {formatValue(result)}
               </pre>


### PR DESCRIPTION
Fixes #29

## Summary
- shift the demo from the slate-heavy shell to an Annona marble/white base with restrained blue accents
- keep the raw panel warmer and the grounded panel cooler to preserve the comparison distinction
- restyle the password gate, top shell, prompts, comparison explainer, panels, and tool cards for stronger light-theme readability

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test:e2e -- tests/e2e/demo-flow.spec.ts tests/e2e/visual-review.spec.ts`
- `npm run visual:review:mock`

## Screenshot Artifacts
- `artifacts/visual-review-inputs/screenshots/01-password-gate.png`
- `artifacts/visual-review-inputs/screenshots/02-authenticated-comparison.png`
- `artifacts/visual-review-inputs/screenshots/03-post-prompt-grounded-response.png`