### PR TITLE
Fix #34: rewrite Annona orchestration spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@
 
 This repository ships the Annona two-agent demo. The target experience is:
 
-- **Left / raw agent**: same bundled data baseline and same native provider tool surface, but no Annona-specific tools
-- **Right / grounded agent**: the same baseline plus Annona tools, calculators, datasets, and model-backed analysis
+- **Left / raw agent**: the same shared CSV / tabular baseline and the same native provider tool surface, interpreted generically
+- **Right / grounded agent**: the same shared baseline, but with Annona's dataset-adaptive orchestration, planning, and answer evaluation
 
 ## Canonical Spec Files
 
@@ -15,6 +15,11 @@ Treat these files as the source of truth for product behavior:
 - `docs/demo-acceptance.md`
 - `docs/capability-matrix.json`
 - `tests/fixtures/demo-scenarios.js`
+
+Closely coupled authority files should stay aligned when relevant:
+
+- `data/openai-native/capability-baseline-notes.md`
+- `docs/site-prd-demo-plan.md`
 
 Issue bodies should point to these files. They should not silently replace them.
 

--- a/data/openai-native/capability-baseline-notes.md
+++ b/data/openai-native/capability-baseline-notes.md
@@ -1,17 +1,29 @@
 ## Shared native tool baseline
 
-These files exist to demonstrate the native OpenAI web, file, and sandbox workflows that are available to both panels in this demo.
+These files exist to demonstrate the shared baseline available to both panels in
+the Annona demo:
+
+- CSV / tabular dataset access
+- web search when the provider supports it
+- code execution when the provider supports it
+
+The canonical product framing is that both panels start from the same uploaded
+tabular baseline. In the current test harness, that baseline is represented by
+static bundled demo files standing in for uploaded inputs.
 
 Important limits:
 
 - They are static demo assets bundled with the app.
 - They are not live ERP, warehouse, or customer data.
 - They are not a general local filesystem browser.
-- They are not a user-upload flow.
+- They are an upload surrogate, not a finished end-user upload UX.
 
 Bundled files in this shared baseline:
 
 - `capability-baseline-notes.md`: this note.
 - `global_freight_benchmarks.csv`: a small illustrative supply-chain benchmark table.
+- `demo_order_margin_snapshot.csv`: a small illustrative order-margin table.
+- `demo_order_margin_reference.md`: the worked margin formula and numbers.
 
-The grounded Annona panel has additional Annona-specific tools and datasets beyond this shared native baseline.
+Annona's differentiation is not hidden data access. It is the dataset-adaptive
+orchestration layer applied on top of the same shared baseline.

--- a/docs/brand-spec.md
+++ b/docs/brand-spec.md
@@ -4,7 +4,71 @@
 
 - Brand: **Annona**
 - Website: `https://goannona.com`
-- Tagline: **See clearly. Act early.**
+- Core promise: **See clearly. Act early.**
+- Category: **Decision intelligence for operations**
+
+## Product Framing
+
+Annona is the decision layer for operations teams. It is not positioned as
+another dashboard, generic copilot, or black-box analyst. The product promise
+is that Annona surfaces what matters, explains why it matters, and recommends
+what to do next with traceable context.
+
+For the demo spec, Annona must be framed as a **dataset-adaptive orchestrator**:
+
+- both agents start from the same baseline of CSV / tabular data, web search,
+  and code execution
+- the raw panel reasons over that baseline generically
+- the Annona panel adapts to the uploaded dataset, profiles it, chooses stable
+  analysis primitives, plans the answer, and evaluates the recommendation before
+  presenting it
+
+## Messaging Pillars
+
+### Clarity
+
+- Remove noise
+- Surface what matters
+- Replace dashboard sprawl with a clear recommendation and supporting context
+
+### Action
+
+- Every output should point to a decision
+- The preferred response shape is `Situation -> Impact -> Action`
+- Answers should help an operations team move, not just inspect
+
+### Timing
+
+- Earlier beats perfect
+- The product should emphasize early signals, not lagging explanations
+- Predictive and prescriptive prompts are part of the canonical demo, not edge
+  cases
+
+### Trust
+
+- Explainable
+- Traceable
+- No black boxes
+- Recommendations must show enough context that a human operator can validate
+  them quickly
+
+## Copy Guidance
+
+Preferred phrases:
+
+- `See clearly. Act early.`
+- `Decision intelligence for operations`
+- `Clear recommendation with context`
+- `Explainable. Traceable. No black boxes.`
+- `What is happening, why it matters, and what to do next`
+
+Avoid:
+
+- `another dashboard`
+- vague `AI insights` phrasing without operational consequence
+- claims that imply hidden magic instead of transparent reasoning
+- speculative product language that sounds more like model capability marketing
+  than operational software
 
 ## Logo / Wordmark
 
@@ -38,8 +102,9 @@ Extracted from `goannona.com`:
 
 ## Tone
 
-- Minimal
-- Clear
+- Crisp
 - Operational
 - High-trust
-- Not generic neon-AI
+- Minimal, but not sterile
+- Clear before clever
+- Confident without hype

--- a/docs/capability-matrix.json
+++ b/docs/capability-matrix.json
@@ -1,39 +1,107 @@
 {
-  "version": "2026-04-04",
+  "version": "2026-04-05",
   "brandName": "Annona",
+  "category": "decision_intelligence_for_operations",
+  "corePromise": "See clearly. Act early.",
   "sharedBaseline": {
+    "description": "Both panels begin from the same tabular-data baseline and the same native web and code surface.",
     "data": [
-      "bundled demo CSV / snapshot"
+      "uploaded CSV / tabular datasets",
+      "canonical bundled fixture used as the upload surrogate in tests"
     ],
     "nativeProviderTools": [
       "web_search",
       "code_sandbox",
-      "file_artifact_workflows"
+      "tabular_file_search"
+    ],
+    "truthConstraints": [
+      "No live ERP or warehouse connection is implied unless explicitly configured.",
+      "Shared baseline access is the same for both panels.",
+      "Web findings must stay distinct from dataset findings."
     ]
   },
   "leftAgent": {
     "id": "raw",
     "name": "Ungrounded / Raw Agent",
     "inheritsSharedBaseline": true,
-    "annonaSpecificTools": []
+    "role": "generic_model_over_shared_baseline",
+    "strengths": [
+      "direct file inspection",
+      "generic calculations",
+      "web lookups when available"
+    ],
+    "constraints": [
+      "No Annona orchestration layer",
+      "No dataset-adaptive planning contract",
+      "No explicit answer-evaluation pass before final response"
+    ]
   },
   "rightAgent": {
     "id": "grounded",
     "name": "Grounded Annona Agent",
     "inheritsSharedBaseline": true,
-    "annonaSpecificTools": [
-      "annona_margin_lookup",
-      "annona_stockout_risk",
-      "annona_supplier_margin_leakage"
+    "role": "dataset_adaptive_orchestrator",
+    "differentiators": [
+      "dataset intake and profiling",
+      "semantic understanding of tabular inputs",
+      "stable analysis primitives",
+      "orchestration and answer planning",
+      "answer evaluation before response"
+    ],
+    "outputContract": [
+      "clear recommendation with context",
+      "situation_impact_action structure when a decision is required",
+      "explainable and traceable reasoning",
+      "no dashboard sprawl or black-box claims"
+    ]
+  },
+  "annonaFlow": {
+    "stages": [
+      {
+        "id": "intake_profile",
+        "label": "Dataset intake and profiling",
+        "outcome": "Identify available tables, fields, row counts, and basic data quality signals."
+      },
+      {
+        "id": "semantic_understanding",
+        "label": "Semantic understanding",
+        "outcome": "Infer operational meaning such as orders, lanes, timing, cost, reliability, margin, and action surfaces."
+      },
+      {
+        "id": "analysis_primitives",
+        "label": "Stable analysis primitives",
+        "outcome": "Prefer reusable primitives like variance, ranking, thresholding, trend framing, and recommendation synthesis over ad hoc tool invention."
+      },
+      {
+        "id": "orchestration_planning",
+        "label": "Orchestration and planning",
+        "outcome": "Select the right sequence of inspection, calculation, and contextualization steps for the prompt."
+      },
+      {
+        "id": "answer_evaluation",
+        "label": "Answer evaluation",
+        "outcome": "Check whether the recommendation is supported, scoped, and operationally usable before finalizing it."
+      }
+    ],
+    "stableAnalysisPrimitives": [
+      "dataset profiling",
+      "schema-to-meaning mapping",
+      "margin decomposition",
+      "variance ranking",
+      "service-risk ranking",
+      "future-state risk framing",
+      "recommendation synthesis",
+      "answer self-check"
     ]
   },
   "providerConditions": {
     "openai": {
-      "nativeProviderToolsAvailable": true
+      "nativeProviderToolsAvailable": true,
+      "notes": "Web search, file workflows, and code execution can be part of the shared baseline when OpenAI native tooling is configured."
     },
     "anthropic": {
       "nativeProviderToolsAvailable": false,
-      "notes": "Fall back to honest disclosure until equivalent native tooling is wired"
+      "notes": "Fall back to honest disclosure until equivalent native tooling is wired."
     }
   }
 }

--- a/docs/demo-acceptance.md
+++ b/docs/demo-acceptance.md
@@ -2,40 +2,89 @@
 
 Canonical prompt and answer expectations live in
 [`tests/fixtures/demo-scenarios.js`](/home/jack/workspace/supplie-demo/tests/fixtures/demo-scenarios.js).
-Any change to the demo prompt set, expected answers, or answer-review behavior
-must update that fixture in the same branch.
+Any change to the demo prompt set, answer behavior, or review rubric must update
+that fixture in the same branch.
+
+## Acceptance Goal
+
+The demo is accepted only when it presents a truthful side-by-side comparison:
+
+- both panels receive the same baseline of CSV / tabular data, web search, and
+  code execution
+- the left panel shows what a generic model does with that baseline
+- the right panel shows how Annona turns the same baseline into a clearer,
+  earlier, more operational recommendation
+
+The differentiator is not hidden data access. The differentiator is Annona's
+dataset-adaptive orchestration.
 
 ## Core Flow
 
-The demo is accepted only when the live dev deployment can show this end-to-end:
+The demo must show this end-to-end:
 
 1. Password gate loads
 2. Demo unlocks
 3. Both panels render
-4. A known prompt can be submitted
-5. Left/raw panel responds honestly from the shared baseline
-6. Right/grounded panel responds with the expected grounded Annona result
-7. No runtime/module error is shown
+4. A tabular dataset baseline is available to both panels
+5. A canonical prompt can be submitted to both panels
+6. The raw panel responds honestly from the shared baseline
+7. The Annona panel responds from the same baseline, but with Annona's
+   orchestration flow
+8. The response shows no runtime or module failure
 
-## Prompt Coverage
+In the current test harness, the shared dataset baseline may be represented by a
+canonical bundled fixture rather than a live upload UI. That does not change the
+spec: the baseline is shared tabular data.
 
-Every demo prompt in the canonical fixture must have:
+## Annona Flow Requirement
 
-- an authoritative raw expectation
-- an authoritative grounded expectation
-- the correct answer path called out explicitly, such as shared bundle,
-  shared native web/code, or Annona grounded snapshot
-- answer-review coverage in the Playwright and visual-review flows
+The grounded Annona panel is accepted only if the spec, prompts, and review
+rubric all align on this flow:
 
-For prompts answerable from shared bundled files, the raw panel is judged against
-the shared-bundle answer path even if the prose is less polished than the
-grounded panel. For Annona-grounded scenarios, the grounded panel is judged
-against the Annona-specific expected answer path.
+1. Dataset intake and profiling
+2. Semantic understanding of the tabular inputs
+3. Stable analysis primitive selection
+4. Orchestration and answer planning
+5. Answer evaluation before final response
+
+The final answer should read like a high-trust operational recommendation, not a
+tool dump or dashboard summary.
+
+## Canonical Scenario Structure
+
+Every canonical scenario in the fixture must declare:
+
+- the user prompt
+- whether the prompt is answerable from the shared tabular bundle alone
+- prompt class, including direct, predictive, or prescriptive framing
+- data prerequisites
+- expected raw behavior
+- expected Annona behavior
+- correctness rubric
+- authoritative raw and grounded expectations for automated review
+
+At least two canonical prompts must be future-state, predictive, or
+prescriptive. The prompt set is not accepted if it collapses into simple data
+lookups.
+
+## Review Expectations
+
+For every canonical scenario:
+
+- the raw panel may calculate, inspect files, search the web, or use code, but
+  it should read as a generic model working directly from the shared baseline
+- the Annona panel should profile the data, use stable analysis primitives,
+  and return a recommendation with context
+- both panels must stay explainable and honest about what came from the dataset
+  versus the web
+- automated review must check the expected answer path, key facts, and tool
+  evidence
 
 ## Done Criteria
 
-A feature touching the demo is only truly done when:
+A demo change is done only when:
 
-- PR is green
-- deploy completes
-- live QA passes against the intended flow
+- the canonical spec files are updated together where relevant
+- local validation passes at the strongest relevant level
+- the branch is pushed and reviewed
+- deploy and live QA, when run, match the intended spec

--- a/docs/site-prd-demo-plan.md
+++ b/docs/site-prd-demo-plan.md
@@ -8,11 +8,10 @@ against screenshots.
 ## Product Intent
 
 - The demo must present a trustworthy side-by-side comparison between two agents.
-- The left panel is the ungrounded / raw agent and must stay ungrounded relative
-  to Annona data.
-- The right panel is the grounded Annona agent and must be a strict superset of
-  the left panel, adding Annona-specific grounded tooling behavior and, when the
-  provider is configured, the same shared native provider tooling baseline.
+- The left panel is the ungrounded / raw agent and must behave like a generic
+  model working directly from the shared baseline.
+- The right panel is the grounded Annona agent and must show the same shared
+  baseline transformed by Annona's dataset-adaptive orchestration flow.
 - The UI must disclose capabilities and limitations truthfully instead of
   implying unavailable features.
 - A password gate must block the demo until the user authenticates.
@@ -31,7 +30,7 @@ against screenshots.
 - The top bar shows `Annona`, `Grounding Demo`, the model picker, and the
   clear button.
 - Prompt chips are visible beneath the top bar.
-- A `Live Comparison` explainer is visible.
+- A `Live Comparison` explainer is visible and makes the comparison logic clear.
 - Two equal-width panels are visible side by side on desktop.
 - The left panel title is `Ungrounded / Raw Agent`.
 - The right panel title is `Grounded Annona Agent`.
@@ -42,10 +41,14 @@ against screenshots.
 ### 3. Post-Prompt Response
 
 - The same user prompt appears in both panels.
-- The left panel response is visibly framed as ungrounded relative to Annona data.
-- The right panel response is visibly framed as grounded Annona output.
-- The grounded panel includes tool evidence for shared native tools and the Annona grounded lookup.
-- The grounded result references the snapshot finding for `Atlas Springs`.
+- The left panel response is visibly framed as a generic read of the shared
+  baseline.
+- The right panel response is visibly framed as Annona output over the same
+  baseline.
+- The grounded panel includes tool evidence for dataset profiling, analysis, or
+  answer evaluation rather than reading like a plain lookup.
+- When the prompt is prescriptive, the grounded result resolves to a clear
+  recommendation with context.
 
 ## Visual Acceptance Criteria
 
@@ -54,10 +57,12 @@ against screenshots.
 - `comparison_layout`: the desktop layout clearly communicates a left-vs-right
   comparison without clipped, overlapping, or collapsed regions.
 - `truthful_disclosure`: labels, explainer copy, and panel notes do not
-  overclaim live ERP, Annona grounding, arbitrary filesystem access, or other
-  missing capabilities.
+  overclaim live ERP access, hidden data access, arbitrary filesystem access, or
+  other missing capabilities.
 - `grounded_evidence_visibility`: the grounded panel makes its tool-backed
-  evidence visually distinct from the raw panel.
+  orchestration evidence visually distinct from the raw panel.
+- `operational_recommendation_shape`: Annona answers read as operational
+  recommendations with context, not dashboard sprawl.
 - `readability_and_polish`: text is readable, contrast is acceptable, spacing is
   coherent, and the screen does not look broken or unfinished.
 
@@ -67,8 +72,10 @@ against screenshots.
 - Either panel is missing, mislabeled, or no longer clearly side by side on the
   desktop capture.
 - The password gate exposes protected content before authentication.
-- The grounded panel does not visually distinguish grounded evidence from the
-  raw panel.
+- The grounded panel does not visually distinguish Annona orchestration evidence
+  from the raw panel.
+- The prompt set shown in the UI collapses into simple retrospective lookups and
+  omits predictive or prescriptive questions.
 - Text is clipped, overlapping, or unreadable in any captured state.
 - The screenshots show obvious loading failure, blank output, or severe visual
   regression.

--- a/tests/fixtures/demo-scenarios.js
+++ b/tests/fixtures/demo-scenarios.js
@@ -24,7 +24,12 @@
  * @typedef {{
  *   id: string;
  *   prompt: string;
+ *   promptClass: "descriptive" | "analytical" | "predictive" | "prescriptive";
  *   sharedBundleAnswerable: boolean;
+ *   dataPrerequisites: string[];
+ *   expectedRawBehavior: string;
+ *   expectedAnnonaBehavior: string;
+ *   correctnessRubric: string[];
  *   expectedRaw: DemoScenarioExpectation;
  *   expectedGrounded: DemoScenarioExpectation;
  * }} DemoScenario
@@ -62,25 +67,146 @@
 /** @type {DemoScenario[]} */
 export const DEMO_SCENARIOS = [
   {
+    id: "dataset-intake-profile",
+    prompt:
+      "I uploaded a margin snapshot and a freight benchmark table. What do they cover, and what decisions are they fit for right now?",
+    promptClass: "descriptive",
+    sharedBundleAnswerable: true,
+    dataPrerequisites: [
+      "Shared tabular baseline with demo_order_margin_snapshot.csv",
+      "Shared tabular baseline with global_freight_benchmarks.csv",
+      "Basic file inspection or profiling capability",
+    ],
+    expectedRawBehavior:
+      "Raw should summarize the two shared tabular inputs accurately, name the operational questions they support, and stay honest that this is a generic read of the shared dataset.",
+    expectedAnnonaBehavior:
+      "Annona should frame the same inputs as a profiled decision surface, distinguishing order-economics analysis from lane-risk analysis and translating them into immediate operational decisions.",
+    correctnessRubric: [
+      "Names both datasets and their operational meaning.",
+      "Keeps the answer grounded in the same shared baseline for both panels.",
+      "Annona answer reads as intake plus semantic understanding, not just a file listing.",
+    ],
+    expectedRaw: {
+      answerPath: "shared-tabular-baseline",
+      rubric:
+        "Raw should inspect the shared uploaded or bundled tables, describe them accurately, and identify the decisions they support without implying Annona-only access.",
+      canonicalAnswer:
+        "Raw baseline answer: the shared tabular baseline contains a three-row Suspension King order margin snapshot and an eight-row freight benchmark table. From these files I can inspect order economics, calculate net margin, compare lane transit, cost, and reliability, and flag where to look next, but this is still a generic read of the shared dataset.",
+      mustContainAll: [
+        "Suspension King",
+        "freight benchmark",
+        "shared dataset",
+      ],
+      mustContainOneOf: [
+        ["three-row", "3-row", "three row"],
+        ["eight-row", "8-row", "eight row"],
+        ["net margin", "margin"],
+        ["transit", "cost", "reliability"],
+      ],
+      requiredToolOneOf: [["openai_file_search", "openai_code_interpreter"]],
+      mockToolInvocations: [
+        {
+          toolName: "openai_file_search",
+          args: {
+            queries: ["profile uploaded margin snapshot and freight benchmark"],
+          },
+          result: {
+            status: "completed",
+            results: [
+              {
+                filename: "demo_order_margin_snapshot.csv",
+                score: 0.98,
+              },
+              {
+                filename: "global_freight_benchmarks.csv",
+                score: 0.97,
+              },
+            ],
+          },
+        },
+      ],
+    },
+    expectedGrounded: {
+      answerPath: "annona-orchestrated-shared-baseline",
+      rubric:
+        "Annona should use the same shared baseline, but describe it as a profiled operational dataset and map it to immediate decisions rather than stopping at file description.",
+      canonicalAnswer:
+        "Annona answer: dataset intake shows two shared tabular inputs, a last-week Suspension King order margin snapshot and a multi-lane freight benchmark table. Annona treats them as an order-economics dataset plus a lane-risk dataset, so the immediate decision surface is margin leakage, service-risk watchpoints, and which action to take first. This is the same shared dataset, but Annona has already profiled it and mapped it to the next operational decisions.",
+      mustContainAll: [
+        "dataset intake",
+        "same shared dataset",
+        "order-economics dataset",
+        "lane-risk dataset",
+      ],
+      mustContainOneOf: [
+        ["margin leakage", "margin"],
+        ["service-risk watchpoints", "service risk", "watchpoints"],
+        ["action to take first", "next operational decisions"],
+      ],
+      requiredTools: ["annona_profile_tabular_inputs"],
+      mockToolInvocations: [
+        {
+          toolName: "annona_profile_tabular_inputs",
+          args: {
+            datasets: [
+              "demo_order_margin_snapshot.csv",
+              "global_freight_benchmarks.csv",
+            ],
+          },
+          result: {
+            datasets: [
+              {
+                name: "demo_order_margin_snapshot.csv",
+                inferred_domain: "order_economics",
+                row_count: 3,
+              },
+              {
+                name: "global_freight_benchmarks.csv",
+                inferred_domain: "lane_risk",
+                row_count: 8,
+              },
+            ],
+            suggested_decisions: [
+              "margin protection",
+              "service-risk review",
+              "lane prioritization",
+            ],
+          },
+        },
+      ],
+    },
+  },
+  {
     id: "suspension-king-net-margin",
     prompt:
       "What's the net margin on last week's Suspension King orders after freight and rebates?",
+    promptClass: "analytical",
     sharedBundleAnswerable: true,
+    dataPrerequisites: [
+      "Shared tabular baseline with demo_order_margin_snapshot.csv",
+      "Shared formula reference in demo_order_margin_reference.md",
+      "Calculation capability via code or structured reasoning",
+    ],
+    expectedRawBehavior:
+      "Raw should calculate the net margin from the shared margin snapshot and disclose that the answer came from the shared dataset.",
+    expectedAnnonaBehavior:
+      "Annona should return the same number, but in a traceable form that makes the decomposition and evidence obvious.",
+    correctnessRubric: [
+      "Uses the correct margin formula.",
+      "Returns $7,990 as the total net margin.",
+      "Annona answer is explainable and traceable rather than merely numerical.",
+    ],
     expectedRaw: {
-      answerPath: "shared-bundle",
+      answerPath: "shared-tabular-baseline",
       rubric:
-        "Raw should answer from the shared bundled margin CSV/reference files, state the net margin result, and stay explicit that this is not Annona-only grounded access.",
+        "Raw should answer from the shared uploaded or bundled margin files, state the net margin result, and stay explicit that this came from the shared dataset rather than Annona-only access.",
       canonicalAnswer:
-        "Raw shared-bundle answer: using the bundled demo_order_margin_snapshot.csv and the bundled margin reference, Suspension King's three sample orders total $43,940 revenue, $31,480 COGS, $3,080 freight, and $1,390 rebates, leaving a net margin of $7,990. This comes from the shared demo files, not Annona-only grounded access.",
-      mustContainAll: ["Suspension King", "net margin"],
+        "Raw shared-baseline answer: using the shared demo_order_margin_snapshot.csv and the margin reference, Suspension King's three sample orders total $43,940 revenue, $31,480 COGS, $3,080 freight, and $1,390 rebates, leaving a net margin of $7,990. This comes from the shared dataset, not Annona-only access.",
+      mustContainAll: ["Suspension King", "net margin", "shared dataset"],
       mustContainOneOf: [
         ["7,990", "7990"],
-        ["shared demo files", "shared bundle", "bundled"],
-        [
-          "not Annona-only grounded access",
-          "not grounded Annona access",
-          "not Annona-only data",
-        ],
+        ["shared demo_order_margin_snapshot.csv", "shared dataset"],
+        ["43,940", "43940"],
       ],
       requiredToolOneOf: [["openai_file_search", "openai_code_interpreter"]],
       mockToolInvocations: [
@@ -123,83 +249,88 @@ export const DEMO_SCENARIOS = [
       ],
     },
     expectedGrounded: {
-      answerPath: "annona-grounded-snapshot",
+      answerPath: "annona-orchestrated-shared-baseline",
       rubric:
-        "Grounded should answer from the Annona snapshot path, state the same $7,990 result, and disclose that it came from the static Annona demo snapshot rather than live systems.",
+        "Annona should answer from the same shared dataset, state the same $7,990 result, and show a traceable decomposition rather than implying special hidden data.",
       canonicalAnswer:
-        "Grounded Annona answer: the static Annona demo snapshot shows Suspension King's last-week sample orders at $43,940 revenue, $31,480 COGS, $3,080 freight, and $1,390 rebates, for a net margin of $7,990. This is from the bundled Annona demo snapshot, not live ERP data.",
-      mustContainAll: ["Suspension King", "Annona demo snapshot", "net margin"],
-      mustContainOneOf: [["7,990", "7990"]],
-      requiredTools: ["annona_query_order_margin_snapshot"],
+        "Annona answer: from the same shared margin snapshot, Suspension King's last-week sample orders resolve to $43,940 revenue, $31,480 COGS, $3,080 freight, and $1,390 rebates, for a traceable net margin of $7,990. Annona surfaces the decomposition so the recommendation path stays explainable and does not depend on a black box.",
+      mustContainAll: [
+        "same shared margin snapshot",
+        "traceable net margin",
+        "Suspension King",
+      ],
+      mustContainOneOf: [
+        ["7,990", "7990"],
+        ["explainable", "traceable"],
+        ["black box", "black-box"],
+      ],
+      requiredTools: ["annona_run_margin_analysis"],
       mockToolInvocations: [
         {
-          toolName: "openai_file_search",
+          toolName: "annona_run_margin_analysis",
           args: {
-            queries: ["demo_order_margin_reference.md bundled margin formula"],
+            dataset: "demo_order_margin_snapshot.csv",
+            metric: "net_margin",
           },
           result: {
-            status: "completed",
-            results: [
-              {
-                filename: "demo_order_margin_reference.md",
-                score: 0.92,
-              },
-            ],
-          },
-        },
-        {
-          toolName: "annona_query_order_margin_snapshot",
-          args: {
             customer: "Suspension King",
-            period: "last_week",
-          },
-          result: {
-            snapshot_id: "annona-demo-snapshot-2026-03-22",
-            customer: "Suspension King",
-            total_orders: 3,
             revenue: 43940,
             cogs: 31480,
             freight: 3080,
             rebates: 1390,
             net_margin: 7990,
             margin_pct: 18.2,
+            explainability: "Revenue - COGS - freight - rebates across 3 rows",
           },
         },
       ],
     },
   },
   {
-    id: "stockout-risk-30-day",
-    prompt: "Which SKUs are at risk of stockout in the next 30 days?",
-    sharedBundleAnswerable: false,
+    id: "protect-margin-next-week",
+    prompt:
+      "If we want to protect Suspension King's margin next week, which order pattern should operations intervene on first, and what should they do now?",
+    promptClass: "prescriptive",
+    sharedBundleAnswerable: true,
+    dataPrerequisites: [
+      "Shared tabular baseline with demo_order_margin_snapshot.csv",
+      "Ability to rank rows by net margin and cost pressure",
+      "Operational recommendation framing",
+    ],
+    expectedRawBehavior:
+      "Raw should identify the weakest order pattern from the shared margin data and make a sensible but generic recommendation.",
+    expectedAnnonaBehavior:
+      "Annona should identify the same weak point, explain the impact, and resolve the answer into a clear situation, impact, and action recommendation.",
+    correctnessRubric: [
+      "Flags SK-240321-03 or the equivalent lowest-margin pattern first.",
+      "Recognizes that the order is near break-even at $490 net margin or 4.4% margin.",
+      "Annona answer specifies what to do now, not just what happened.",
+    ],
     expectedRaw: {
-      answerPath: "shared-bundle-limitation",
+      answerPath: "shared-tabular-baseline",
       rubric:
-        "Raw should say the shared bundle does not include Annona inventory/forecast snapshot data, so it cannot identify stockout-risk SKUs from the available files.",
+        "Raw should use the shared margin snapshot to identify the weakest pattern and recommend a first intervention without pretending to have extra Annona-only context.",
       canonicalAnswer:
-        "Raw panel limitation: I cannot identify 30-day stockout-risk SKUs from the shared bundle because those shared files only cover margin and benchmark examples; they do not include the Annona inventory and forecast snapshot needed for a stockout answer.",
-      mustContainAll: ["stockout", "shared bundle"],
+        "Raw recommendation: the first pattern to intervene on is the SK-240321-03 order profile because it only leaves $490 of net margin, about 4.4 percent, after $980 freight and $410 rebates. From the shared margin snapshot, the practical next step is to review freight pass-through and rebate approvals before similar orders ship next week.",
+      mustContainAll: ["SK-240321-03", "shared margin snapshot"],
       mustContainOneOf: [
-        ["cannot identify", "can't identify", "cannot determine"],
-        [
-          "do not include the Annona inventory and forecast snapshot",
-          "do not include Annona stock snapshot data",
-          "do not include Annona inventory data",
-        ],
+        ["490", "$490"],
+        ["4.4", "4.4 percent", "4.4%"],
+        ["freight pass-through", "rebate approvals", "rebates"],
       ],
-      requiredToolOneOf: [["openai_file_search"]],
+      requiredTools: ["openai_code_interpreter"],
       mockToolInvocations: [
         {
-          toolName: "openai_file_search",
+          toolName: "openai_code_interpreter",
           args: {
-            queries: ["stockout risk inventory forecast shared bundle files"],
+            task: "Rank the Suspension King rows by net margin and highlight the weakest pattern.",
           },
           result: {
-            status: "completed",
-            results: [
+            outputs: [
               {
-                filename: "capability-baseline-notes.md",
-                score: 0.74,
+                type: "logs",
+                content:
+                  "Lowest margin row=SK-240321-03, net_margin=490, margin_pct=4.4, freight=980, rebates=410",
               },
             ],
           },
@@ -207,94 +338,107 @@ export const DEMO_SCENARIOS = [
       ],
     },
     expectedGrounded: {
-      answerPath: "annona-grounded-snapshot",
+      answerPath: "annona-orchestrated-shared-baseline",
       rubric:
-        "Grounded should answer from the Annona stock-risk snapshot, name the at-risk SKUs, and distinguish the urgent items.",
+        "Annona should use the same shared margin rows, identify the weak order pattern, and turn it into a clear operational recommendation with context and traceability.",
       canonicalAnswer:
-        "Grounded Annona answer: in the static Annona demo snapshot, the 30-day stockout-risk SKUs are COIL-PRADO-450, UCA-RANGER-22, SHOCK-HILUX-MT, and BUSH-KIT-80S. The urgent items are COIL-PRADO-450 with 12 days remaining and UCA-RANGER-22 with 14 days remaining.",
+        "Annona recommendation: Situation: the SK-240321-03 pattern is the weak point in the shared margin snapshot at $490 net margin, or 4.4 percent, with freight and rebates consuming most of the gross buffer. Impact: if that pattern repeats next week, the account stays near break-even and small cost movement can erase margin. Action: review freight pass-through and rebate approval on lookalike orders before the next shipment, starting with orders that resemble SK-240321-03. This recommendation is traceable to the uploaded order rows.",
       mustContainAll: [
-        "Annona demo snapshot",
-        "COIL-PRADO-450",
-        "UCA-RANGER-22",
-        "SHOCK-HILUX-MT",
-        "BUSH-KIT-80S",
+        "Situation:",
+        "Impact:",
+        "Action:",
+        "SK-240321-03",
+        "uploaded order rows",
       ],
       mustContainOneOf: [
-        ["urgent", "urgent items"],
-        ["12 days remaining", "12 days"],
-        ["14 days remaining", "14 days"],
+        ["490", "$490"],
+        ["4.4", "4.4 percent", "4.4%"],
+        ["traceable", "explainable"],
       ],
-      requiredTools: ["annona_query_stockout_risk_snapshot"],
+      requiredTools: [
+        "annona_plan_margin_intervention",
+        "annona_evaluate_recommendation",
+      ],
       mockToolInvocations: [
         {
-          toolName: "annona_query_stockout_risk_snapshot",
+          toolName: "annona_plan_margin_intervention",
           args: {
-            horizon_days: 30,
+            dataset: "demo_order_margin_snapshot.csv",
+            objective: "protect margin next week",
           },
           result: {
-            snapshot_id: "annona-demo-snapshot-2026-03-22",
-            horizon_days: 30,
-            exception_count: 4,
-            urgent_count: 2,
-            skus: [
-              {
-                sku: "COIL-PRADO-450",
-                days_remaining: 12,
-                urgent: true,
-              },
-              {
-                sku: "UCA-RANGER-22",
-                days_remaining: 14,
-                urgent: true,
-              },
-              {
-                sku: "SHOCK-HILUX-MT",
-                days_remaining: 20,
-                urgent: false,
-              },
-              {
-                sku: "BUSH-KIT-80S",
-                days_remaining: 28,
-                urgent: false,
-              },
-            ],
+            focus_pattern: "SK-240321-03",
+            net_margin: 490,
+            margin_pct: 4.4,
+            driver: "freight and rebate drag",
+            recommended_action:
+              "Review freight pass-through and rebate approval before next shipment",
+          },
+        },
+        {
+          toolName: "annona_evaluate_recommendation",
+          args: {
+            check: "traceability and actionability",
+          },
+          result: {
+            grounded: true,
+            action_oriented: true,
+            traceable_to_rows: true,
           },
         },
       ],
     },
   },
   {
-    id: "supplier-margin-leakage",
-    prompt: "Which supplier is causing the most margin leakage?",
-    sharedBundleAnswerable: false,
+    id: "lane-service-risk-next-month",
+    prompt:
+      "Which freight lane looks most likely to create service risk next month, and what is the earliest action to take now?",
+    promptClass: "predictive",
+    sharedBundleAnswerable: true,
+    dataPrerequisites: [
+      "Shared tabular baseline with global_freight_benchmarks.csv",
+      "Ability to compare transit time, cost, and reliability",
+      "Future-state risk framing",
+    ],
+    expectedRawBehavior:
+      "Raw should identify the riskiest lane from the shared freight table and give a sensible early action, but it may stay relatively generic.",
+    expectedAnnonaBehavior:
+      "Annona should identify the same lane, explain why it matters before failure lands, and specify the earliest intervention in operational language.",
+    correctnessRubric: [
+      "Flags Ningbo-Rotterdam on HarborSpan as the top service-risk watchpoint.",
+      "Uses the supporting facts: 28 transit days, 88 percent reliability, $3,340 cost.",
+      "Annona answer frames the decision as an early operational intervention.",
+    ],
     expectedRaw: {
-      answerPath: "shared-bundle-limitation",
+      answerPath: "shared-tabular-baseline",
       rubric:
-        "Raw should say the shared bundle does not include supplier leakage rankings or the Annona leakage snapshot, so it cannot determine the top leakage supplier from shared files alone.",
+        "Raw should use the shared freight benchmark table to rank likely service risk and name a reasonable early action based on the available data.",
       canonicalAnswer:
-        "Raw panel limitation: I cannot rank supplier margin leakage from the shared bundle because the shared files do not include the Annona supplier leakage snapshot or any supplier leakage ranking table.",
-      mustContainAll: ["supplier margin leakage", "shared bundle"],
-      mustContainOneOf: [
-        ["cannot rank", "can't rank", "cannot determine"],
-        [
-          "do not include the Annona supplier leakage snapshot",
-          "do not include supplier leakage ranking",
-          "missing the Annona leakage snapshot",
-        ],
+        "Raw risk view: Ningbo-Rotterdam on HarborSpan looks most likely to create service risk next month because it has the longest transit time at 28 days, the worst reliability at 88 percent, and the highest cost at $3,340 among the benchmark lanes. From the shared freight table, the earliest action is to review upcoming bookings on that lane now and line up a contingency carrier plan.",
+      mustContainAll: [
+        "Ningbo-Rotterdam",
+        "HarborSpan",
+        "shared freight table",
       ],
-      requiredToolOneOf: [["openai_file_search"]],
+      mustContainOneOf: [
+        ["28 days", "28-day", "28"],
+        ["88 percent", "88%", "88 percent reliability"],
+        ["3,340", "$3,340", "3340"],
+        ["contingency carrier plan", "review upcoming bookings", "contingency"],
+      ],
+      requiredTools: ["openai_code_interpreter"],
       mockToolInvocations: [
         {
-          toolName: "openai_file_search",
+          toolName: "openai_code_interpreter",
           args: {
-            queries: ["supplier margin leakage shared bundle files"],
+            task: "Rank freight lanes by likely service risk using transit_days, reliability_pct, and cost_usd.",
           },
           result: {
-            status: "completed",
-            results: [
+            outputs: [
               {
-                filename: "capability-baseline-notes.md",
-                score: 0.77,
+                type: "logs",
+                content:
+                  "Top watchpoint=Ningbo-Rotterdam / HarborSpan, transit_days=28, reliability_pct=88, cost_usd=3340",
               },
             ],
           },
@@ -302,41 +446,84 @@ export const DEMO_SCENARIOS = [
       ],
     },
     expectedGrounded: {
-      answerPath: "annona-grounded-snapshot",
+      answerPath: "annona-orchestrated-shared-baseline",
       rubric:
-        "Grounded should use the Annona supplier leakage snapshot, identify Atlas Springs as rank 1, and include the leakage amount or primary driver.",
+        "Annona should use the same freight table but turn the ranking into an early operating decision with a clear rationale and next action.",
       canonicalAnswer:
-        "Grounded Annona answer: Atlas Springs is the biggest source of margin leakage in the static Annona demo snapshot, with $11,200 of leakage. The primary driver is freight variance on bulky coil lines, with expedited inbound freight and rebate slippage compressing margin.",
-      mustContainAll: ["Atlas Springs", "Annona demo snapshot"],
-      mustContainOneOf: [["11,200", "11200"]],
-      requiredTools: ["annona_query_supplier_margin_leakage_snapshot"],
+        "Annona recommendation: Situation: Ningbo-Rotterdam on HarborSpan is the first service-risk watchpoint in the shared freight benchmark because it combines the longest transit at 28 days with the lowest reliability at 88 percent and the highest benchmark cost at $3,340. Impact: if the next month follows the same pattern, this lane is the easiest place for delay and cost pressure to land before the team reacts. Action: pull the next bookings on this lane forward into review now and prepare a contingency routing decision before service slips. The recommendation is explainable from the benchmark rows.",
+      mustContainAll: [
+        "Situation:",
+        "Impact:",
+        "Action:",
+        "Ningbo-Rotterdam",
+        "HarborSpan",
+      ],
+      mustContainOneOf: [
+        ["28 days", "28-day", "28"],
+        ["88 percent", "88%", "88 percent reliability"],
+        ["3,340", "$3,340", "3340"],
+        ["benchmark rows", "explainable", "traceable"],
+      ],
+      requiredTools: [
+        "annona_rank_service_risk",
+        "annona_evaluate_recommendation",
+      ],
       mockToolInvocations: [
         {
-          toolName: "annona_query_supplier_margin_leakage_snapshot",
+          toolName: "annona_rank_service_risk",
           args: {
-            top_n: 3,
+            dataset: "global_freight_benchmarks.csv",
+            horizon: "next_month",
           },
           result: {
-            snapshot_id: "annona-demo-snapshot-2026-03-22",
-            supplier: "Atlas Springs",
-            leakage_amount: 11200,
-            primary_driver: "Freight variance on bulky coil lines",
+            top_watchpoint: "Ningbo-Rotterdam",
+            carrier_family: "HarborSpan",
+            transit_days: 28,
+            reliability_pct: 88,
+            cost_usd: 3340,
+          },
+        },
+        {
+          toolName: "annona_evaluate_recommendation",
+          args: {
+            check: "early-action timing",
+          },
+          result: {
+            grounded: true,
+            action_oriented: true,
+            timing_aligned: true,
           },
         },
       ],
     },
   },
   {
-    id: "current-ocean-freight-trend",
-    prompt: "Search the web for a current ocean freight trend and cite what you used.",
+    id: "current-ocean-freight-signal",
+    prompt:
+      "Search the web for a current ocean freight signal and tell me whether it changes what you would do with this dataset.",
+    promptClass: "predictive",
     sharedBundleAnswerable: false,
+    dataPrerequisites: [
+      "Shared web search capability when provider tooling is available",
+      "Shared freight benchmark table for contextualization",
+      "Clear separation between external signal and dataset-derived conclusion",
+    ],
+    expectedRawBehavior:
+      "Raw should provide a current cited ocean-freight signal from the web and give a reasonable but generic view on whether it changes the local read of the dataset.",
+    expectedAnnonaBehavior:
+      "Annona should cite the same kind of web signal, then contextualize it against the shared dataset and state whether the operating recommendation changes.",
+    correctnessRubric: [
+      "Includes citation-style source text for the web signal.",
+      "Keeps web evidence separate from dataset evidence.",
+      "Annona turns the external signal into a concrete change or non-change in operating posture.",
+    ],
     expectedRaw: {
       answerPath: "shared-native-web",
       rubric:
-        "Raw should answer with a current ocean-freight trend from web search, make it explicit that the source is an external citation rather than Annona data, and include some citation-style source text.",
+        "Raw should answer with a current ocean-freight signal from web search, make it explicit that the source is external rather than dataset-derived, and include citation-style source text.",
       canonicalAnswer:
-        "Raw web answer: a current ocean freight trend is that schedule reliability is improving on major lanes while spot rates remain volatile. Source: Demo web-search citation placeholder, April 4, 2026. This is external web research, not Annona snapshot data.",
-      mustContainAll: ["ocean freight", "Source:"],
+        "Raw web answer: a current ocean freight signal is that schedule reliability is improving on some major lanes while spot rates remain volatile. Source: Demo web-search citation placeholder, April 4, 2026. This is external web research, not a finding from the shared dataset. It does not change the local facts in the dataset, but it does reinforce watching lower-reliability ocean lanes closely.",
+      mustContainAll: ["ocean freight", "Source:", "shared dataset"],
       mustContainOneOf: [
         ["current", "currently"],
         ["schedule reliability", "reliability"],
@@ -362,23 +549,27 @@ export const DEMO_SCENARIOS = [
       ],
     },
     expectedGrounded: {
-      answerPath: "shared-native-web",
+      answerPath: "annona-contextualized-web-plus-shared-baseline",
       rubric:
-        "Grounded should also answer via shared native web search for this prompt, include citation-style source text, and avoid implying that the trend came from the Annona snapshot.",
+        "Annona should answer via the same shared native web search, then contextualize the external signal against the shared dataset and state the operational implication clearly.",
       canonicalAnswer:
-        "Grounded web answer: a current ocean freight trend is improving schedule reliability on major lanes alongside volatile spot pricing. Source: Demo web-search citation placeholder, April 4, 2026. This came from shared native web search rather than the Annona snapshot.",
-      mustContainAll: ["ocean freight", "Source:"],
+        "Annona answer: a current ocean freight signal is improving schedule reliability on some major lanes alongside volatile spot pricing. Source: Demo web-search citation placeholder, April 4, 2026. That signal comes from shared native web search, not the dataset itself. It does not overturn the dataset read, so the recommendation stays the same: keep the earliest attention on the weakest ocean lane in the benchmark set and act before service slips.",
+      mustContainAll: ["ocean freight", "Source:", "not the dataset itself"],
       mustContainOneOf: [
         ["current", "currently"],
         ["schedule reliability", "reliability"],
         ["spot pricing", "spot rates", "volatile"],
+        ["recommendation stays the same", "keep the earliest attention", "act before service slips"],
       ],
-      requiredTools: ["openai_web_search"],
+      requiredTools: [
+        "openai_web_search",
+        "annona_contextualize_external_signal",
+      ],
       mockToolInvocations: [
         {
           toolName: "openai_web_search",
           args: {
-            query: "current ocean freight trend",
+            query: "current ocean freight signal schedule reliability spot rates",
           },
           result: {
             status: "completed",
@@ -390,81 +581,15 @@ export const DEMO_SCENARIOS = [
             ],
           },
         },
-      ],
-    },
-  },
-  {
-    id: "inspect-bundled-benchmark-files",
-    prompt: "Inspect the bundled benchmark files and tell me what they contain.",
-    sharedBundleAnswerable: true,
-    expectedRaw: {
-      answerPath: "shared-bundle",
-      rubric:
-        "Raw should inspect the shared bundled files and summarize the file set accurately, including the benchmark CSV and the margin/reference files.",
-      canonicalAnswer:
-        "Raw file inspection answer: the shared bundle includes capability-baseline-notes.md with native-tool limits, global_freight_benchmarks.csv with lane, mode, carrier, region, transit, cost, and reliability columns, demo_order_margin_snapshot.csv with Suspension King order rows, and demo_order_margin_reference.md with the net-margin formula and the $7,990 worked example.",
-      mustContainAll: [
-        "capability-baseline-notes.md",
-        "global_freight_benchmarks.csv",
-        "demo_order_margin_snapshot.csv",
-        "demo_order_margin_reference.md",
-      ],
-      mustContainOneOf: [
-        ["lane", "carrier", "reliability"],
-        ["net-margin formula", "net margin formula"],
-        ["7,990", "7990"],
-      ],
-      requiredToolOneOf: [["openai_file_search"]],
-      mockToolInvocations: [
         {
-          toolName: "openai_file_search",
+          toolName: "annona_contextualize_external_signal",
           args: {
-            queries: ["bundled benchmark files contents"],
+            dataset: "global_freight_benchmarks.csv",
+            signal: "improving schedule reliability with volatile spot pricing",
           },
           result: {
-            status: "completed",
-            results: [
-              { filename: "capability-baseline-notes.md", score: 0.89 },
-              { filename: "global_freight_benchmarks.csv", score: 0.98 },
-              { filename: "demo_order_margin_snapshot.csv", score: 0.96 },
-              { filename: "demo_order_margin_reference.md", score: 0.94 },
-            ],
-          },
-        },
-      ],
-    },
-    expectedGrounded: {
-      answerPath: "shared-bundle",
-      rubric:
-        "Grounded should describe the same shared bundled files accurately and keep the answer aligned with the shared baseline rather than inventing extra Annona-only files.",
-      canonicalAnswer:
-        "Grounded file inspection answer: the shared native file bundle contains capability-baseline-notes.md for tool limits, global_freight_benchmarks.csv for freight benchmark lanes and service metrics, demo_order_margin_snapshot.csv for the Suspension King order rows, and demo_order_margin_reference.md for the net-margin formula and $7,990 example.",
-      mustContainAll: [
-        "capability-baseline-notes.md",
-        "global_freight_benchmarks.csv",
-        "demo_order_margin_snapshot.csv",
-        "demo_order_margin_reference.md",
-      ],
-      mustContainOneOf: [
-        ["freight benchmark", "benchmark lanes", "service metrics"],
-        ["net-margin formula", "net margin formula"],
-        ["7,990", "7990"],
-      ],
-      requiredToolOneOf: [["openai_file_search"]],
-      mockToolInvocations: [
-        {
-          toolName: "openai_file_search",
-          args: {
-            queries: ["bundled benchmark files contents"],
-          },
-          result: {
-            status: "completed",
-            results: [
-              { filename: "capability-baseline-notes.md", score: 0.89 },
-              { filename: "global_freight_benchmarks.csv", score: 0.98 },
-              { filename: "demo_order_margin_snapshot.csv", score: 0.96 },
-              { filename: "demo_order_margin_reference.md", score: 0.94 },
-            ],
+            posture_change: "no_major_change",
+            reinforced_focus: "lowest-reliability ocean lane",
           },
         },
       ],
@@ -472,16 +597,35 @@ export const DEMO_SCENARIOS = [
   },
   {
     id: "average-transit-days",
-    prompt: "Use your code sandbox on the bundled CSV and tell me the average transit days.",
+    prompt:
+      "Use your code sandbox on the freight benchmark CSV and tell me the average transit days.",
+    promptClass: "analytical",
     sharedBundleAnswerable: true,
+    dataPrerequisites: [
+      "Shared tabular baseline with global_freight_benchmarks.csv",
+      "Code execution over CSV rows",
+      "Ability to disclose that the result comes from the shared baseline",
+    ],
+    expectedRawBehavior:
+      "Raw should compute the average transit days from the shared freight CSV and disclose that the answer came from the shared baseline.",
+    expectedAnnonaBehavior:
+      "Annona should return the same computed result, but keep the answer crisp and traceable to the benchmark file.",
+    correctnessRubric: [
+      "Returns 13.875 days, or an equivalent rounded value.",
+      "References the freight benchmark CSV.",
+      "Does not imply hidden Annona-only data.",
+    ],
     expectedRaw: {
-      answerPath: "shared-bundle",
+      answerPath: "shared-tabular-baseline",
       rubric:
-        "Raw should use the shared bundled freight benchmark CSV via the code sandbox, report the average transit days across the CSV, and disclose that the calculation came from the shared bundle rather than Annona-only data.",
+        "Raw should use the shared freight benchmark CSV via the code sandbox, report the average transit days, and disclose that the result came from the shared baseline.",
       canonicalAnswer:
-        "Raw code answer: using the shared bundled global_freight_benchmarks.csv in the code sandbox, the average transit days across all eight rows is 13.875 days, or about 13.9 days rounded. This is from the shared benchmark CSV, not Annona-only data.",
+        "Raw code answer: using the shared global_freight_benchmarks.csv in the code sandbox, the average transit days across all eight rows is 13.875 days, or about 13.9 days rounded. This is from the shared baseline, not hidden Annona-only data.",
       mustContainAll: ["average transit days", "global_freight_benchmarks.csv"],
-      mustContainOneOf: [["13.875", "13.88", "13.9"]],
+      mustContainOneOf: [
+        ["13.875", "13.88", "13.9"],
+        ["shared baseline", "shared dataset"],
+      ],
       requiredTools: ["openai_code_interpreter"],
       mockToolInvocations: [
         {
@@ -502,13 +646,16 @@ export const DEMO_SCENARIOS = [
       ],
     },
     expectedGrounded: {
-      answerPath: "shared-bundle",
+      answerPath: "annona-orchestrated-shared-baseline",
       rubric:
-        "Grounded should also use the shared code sandbox path for this prompt, report the same average transit days result, and keep the answer tied to the shared benchmark CSV.",
+        "Annona should also use the shared code path for this prompt, report the same average transit result, and keep the answer tied to the shared freight CSV.",
       canonicalAnswer:
-        "Grounded code answer: using the shared bundled global_freight_benchmarks.csv in the code sandbox, the average transit days is 13.875 days across eight rows, about 13.9 days rounded. This is a shared benchmark-file calculation rather than an Annona-only snapshot lookup.",
+        "Annona answer: using the same shared global_freight_benchmarks.csv in the code sandbox, the average transit days is 13.875 across eight rows, about 13.9 days rounded. The result is traceable to the benchmark file and does not rely on hidden Annona-only data.",
       mustContainAll: ["average transit days", "global_freight_benchmarks.csv"],
-      mustContainOneOf: [["13.875", "13.88", "13.9"]],
+      mustContainOneOf: [
+        ["13.875", "13.88", "13.9"],
+        ["traceable", "benchmark file"],
+      ],
       requiredTools: ["openai_code_interpreter"],
       mockToolInvocations: [
         {


### PR DESCRIPTION
Closes #34

## Summary
- rewrite the canonical Annona spec around a shared CSV/web/code baseline for both agents
- reframe Annona as a dataset-adaptive orchestrator with intake, semantics, stable primitives, planning, and answer evaluation
- replace the old prompt/eval fixture with a harder mix of descriptive, analytical, predictive, and prescriptive scenarios
- align the brand, acceptance, capability, and visual-review authority docs to the goannona.com messaging

## Validation
- npm run lint
- npm run typecheck
- npm test