### PR TITLE
Fix #8: codify GitHub issue-to-PR flywheel

### DIFF
--- a/.github/agents/supplie-dev.agent.md
+++ b/.github/agents/supplie-dev.agent.md
@@ -23,14 +23,18 @@ instructions: |
 
   ## GitHub Workflow
 
-  1. Read issue context
-  2. Create a dedicated issue branch/worktree
-  3. Implement the change
-  4. Validate locally
-  5. Commit with `Fix #N: ...`
-  6. Push branch
-  7. Open PR with `Closes #N`
-  8. Report completion with PR URL and exact validation run
+  OpenClaw critiques the current state, creates or updates GitHub issues, and sequences the next issue to execute.
+
+  Codex works issue-by-issue:
+  1. Read the assigned GitHub issue and confirm scope against the canonical specs
+  2. Create or switch to a dedicated `issue-N-*` branch/worktree for that issue
+  3. Implement only the scoped change for that issue
+  4. Run the strongest relevant local validation
+  5. For non-trivial changes, commit with `Fix #N: ...`
+  6. Push the branch
+  7. Open a PR with `Closes #N`
+  8. Treat review, deploy, and smoke-test as part of the standard loop before calling the issue done
+  9. Report completion with the PR URL and exact validation run
 
   ## Validation Expectations
 
@@ -41,6 +45,7 @@ instructions: |
   - build / deploy-equivalent smoke
   - Playwright E2E
   - visual review
+  - post-deploy smoke-test / live QA when the change is deployment-sensitive
 
   Local green is not enough if the change is deploy-sensitive.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,12 +35,29 @@ If a PR changes any of the following, update the relevant canonical spec in the 
 
 If implementation changes but spec files do not, treat the work as incomplete.
 
+## Workflow Ownership
+
+- OpenClaw critiques the current repo, product, and live state against the canonical specs
+- OpenClaw creates or updates GitHub issues and sequences the next issue to execute
+- Codex executes one GitHub issue at a time and keeps the branch scope tied to that issue
+
 ## Branching / Codex Rules
 
 - One meaningful issue = one branch = one worktree
+- Use a dedicated `issue-N-*` branch and matching worktree for each active GitHub issue
 - Overlapping UI/copy/capability branches should be stacked or sequenced, not merged blindly in parallel
 - Before running Codex, verify the repo path, remote, branch, and worktree
+- Non-trivial changes require a commit and PR; do not treat uncommitted local edits as done
 - If a Codex run stalls or targets the wrong path, stop it and relaunch cleanly
+
+## Standard Delivery Flywheel
+
+- OpenClaw critiques current state, creates GitHub issues, and sequences the work
+- Codex picks the next issue, creates the dedicated branch/worktree, and implements only that scoped change
+- Run the strongest relevant local validation before committing
+- For non-trivial changes, commit, push the branch, and open a PR linked to the issue
+- Review, deploy, and smoke-test are part of the default loop, not optional follow-up work
+- Close the issue only after the deployed result matches the intended spec
 
 ## Validation Ladder
 
@@ -52,8 +69,10 @@ A change is not done at local green. Use this ladder:
 4. build / deployment-equivalent smoke where relevant
 5. Playwright functional E2E
 6. GPT visual review
-7. deploy
-8. live QA
+7. PR review
+8. deploy
+9. post-deploy smoke-test
+10. live QA
 
 Only treat work as done when the live environment matches the intended spec.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ npm run typecheck
 npm run build
 ```
 
+## Delivery Workflow
+
+- OpenClaw critiques the current state, opens or updates GitHub issues, and sequences the next issue to work.
+- Codex executes one GitHub issue at a time on a dedicated `issue-N-*` branch/worktree.
+- Non-trivial changes are expected to ship through the full GitHub loop: local validation, commit, push, PR, review, deploy, and smoke-test.
+- Work is only done when the deployed result still matches the canonical specs and acceptance docs.
+
 ## AWS EKS Deployment
 
 - Dev CI/CD: [`.github/workflows/dev.yml`](/home/jack/workspace/supplie-demo/.github/workflows/dev.yml)

--- a/docs/demo-acceptance.md
+++ b/docs/demo-acceptance.md
@@ -86,5 +86,7 @@ A demo change is done only when:
 
 - the canonical spec files are updated together where relevant
 - local validation passes at the strongest relevant level
+- non-trivial work is committed on a dedicated issue branch and linked to a PR
 - the branch is pushed and reviewed
-- deploy and live QA, when run, match the intended spec
+- deploy and post-deploy smoke-test, when relevant, match the intended spec
+- live QA, when run, matches the intended spec


### PR DESCRIPTION
## Summary
- codify the OpenClaw -> GitHub issue -> Codex branch/worktree -> PR flywheel in repo instructions
- require commits and PRs for non-trivial changes
- make review, deploy, and smoke-test part of the standard loop

## Validation
- git diff --check -- AGENTS.md .github/agents/supplie-dev.agent.md README.md docs/demo-acceptance.md

Closes #8