### PR TITLE
Fix #5: add structured app logging and deploy diagnostics

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -61,6 +61,12 @@ jobs:
             --region ${{ env.AWS_REGION }} \
             --name ${{ env.EKS_CLUSTER }}
 
+      - name: Cluster snapshot
+        run: |
+          kubectl config current-context
+          kubectl get nodes -o wide
+          kubectl get namespace "${K8S_NAMESPACE}" -o wide
+
       - name: Apply namespace & secrets
         run: |
           sed "s|SUPPLIE_NAMESPACE|${K8S_NAMESPACE}|g" \
@@ -103,6 +109,16 @@ jobs:
             sleep 10
           done
 
+      - name: Show recent app logs
+        if: success()
+        run: |
+          kubectl logs deployment/supplie-demo -n "${K8S_NAMESPACE}" --tail=80 || true
+
+      - name: Collect Kubernetes diagnostics on failure
+        if: failure()
+        run: |
+          bash scripts/collect-k8s-diagnostics.sh "${K8S_NAMESPACE}" "supplie-demo"
+
       - name: Summary
         run: |
           echo "## Deploy Summary" >> $GITHUB_STEP_SUMMARY
@@ -110,3 +126,5 @@ jobs:
           echo "- **supplie-demo image:** \`${{ steps.tags.outputs.supplie_image }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Namespace:** \`${K8S_NAMESPACE}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **URL:** https://${PROD_HOST}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Recent logs:** \`kubectl logs deployment/supplie-demo -n ${K8S_NAMESPACE} --tail=80\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Failure diagnostics:** \`bash scripts/collect-k8s-diagnostics.sh ${K8S_NAMESPACE} supplie-demo\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -180,6 +180,12 @@ jobs:
             --region "${AWS_REGION}" \
             --name "${EKS_CLUSTER}"
 
+      - name: Cluster snapshot
+        run: |
+          kubectl config current-context
+          kubectl get nodes -o wide
+          kubectl get namespace "${K8S_NAMESPACE}" -o wide
+
       - name: Apply namespace
         run: |
           sed "s|SUPPLIE_NAMESPACE|${K8S_NAMESPACE}|g" \
@@ -224,6 +230,16 @@ jobs:
           echo "Timed out waiting for load balancer hostname" >&2
           exit 1
 
+      - name: Show recent app logs
+        if: success()
+        run: |
+          kubectl logs deployment/supplie-demo -n "${K8S_NAMESPACE}" --tail=80 || true
+
+      - name: Collect Kubernetes diagnostics on failure
+        if: failure()
+        run: |
+          bash scripts/collect-k8s-diagnostics.sh "${K8S_NAMESPACE}" "supplie-demo" "supplie-demo-public"
+
       - name: Summary
         run: |
           echo "## Dev Deploy Summary" >> "$GITHUB_STEP_SUMMARY"
@@ -232,6 +248,8 @@ jobs:
           echo "- Namespace: \`${K8S_NAMESPACE}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Load balancer: \`${{ steps.lb.outputs.hostname }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- URL: ${{ steps.lb.outputs.base_url }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Recent logs: \`kubectl logs deployment/supplie-demo -n ${K8S_NAMESPACE} --tail=80\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Failure diagnostics: \`bash scripts/collect-k8s-diagnostics.sh ${K8S_NAMESPACE} supplie-demo supplie-demo-public\`" >> "$GITHUB_STEP_SUMMARY"
 
   smoke-deployed-dev:
     name: Deployed Dev Smoke Test

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Open `http://localhost:3000`.
 ```bash
 npm run lint
 npm run typecheck
+npm test
 npm run build
 ```
 
@@ -54,9 +55,16 @@ npm run build
 - Non-trivial changes are expected to ship through the full GitHub loop: local validation, commit, push, PR, review, deploy, and smoke-test.
 - Work is only done when the deployed result still matches the canonical specs and acceptance docs.
 
+## Logging
+
+- Structured JSON app logs: [`docs/LOGGING.md`](/home/jack/workspace/supplie-demo-issue5/docs/LOGGING.md)
+- API responses include `X-Request-Id` and `X-Trace-Id` so dev/prod requests can be correlated with server logs.
+- Capability state, tool activity, and model-run summaries are logged without printing raw secrets, tokens, or passwords.
+
 ## AWS EKS Deployment
 
 - Dev CI/CD: [`.github/workflows/dev.yml`](/home/jack/workspace/supplie-demo/.github/workflows/dev.yml)
 - Main/prod EKS deploy: [`.github/workflows/deploy-eks.yml`](/home/jack/workspace/supplie-demo/.github/workflows/deploy-eks.yml)
 - Kubernetes manifests: [`k8s/`](/home/jack/workspace/supplie-demo/k8s)
 - Notes: [`docs/AWS_DEPLOYMENT.md`](/home/jack/workspace/supplie-demo/docs/AWS_DEPLOYMENT.md)
+- Logging and diagnostics: [`docs/LOGGING.md`](/home/jack/workspace/supplie-demo/docs/LOGGING.md)

--- a/app/api/auth/check/route.ts
+++ b/app/api/auth/check/route.ts
@@ -1,11 +1,66 @@
 import { NextResponse } from "next/server";
+import {
+  createRequestContext,
+  createResponseHeaders,
+  logInfo,
+  logWarn,
+  serializeError,
+  withRequestContext,
+} from "@/lib/server/app-logger";
 
 export async function POST(req: Request) {
-  const { password } = await req.json();
-  const demoPassword = process.env.DEMO_PASSWORD;
+  const requestContext = createRequestContext(req, {
+    route: "auth_check",
+    method: "POST",
+  });
 
-  if (!demoPassword || password !== demoPassword) {
-    return NextResponse.json({ ok: false }, { status: 401 });
-  }
-  return NextResponse.json({ ok: true });
+  return withRequestContext(requestContext, async () => {
+    let password: unknown;
+
+    try {
+      ({ password } = (await req.json()) as { password?: unknown });
+    } catch (error) {
+      logWarn("api_request_invalid_json", {
+        route: "auth_check",
+        error: serializeError(error),
+      });
+      return NextResponse.json(
+        { ok: false, error: "Request body must be valid JSON." },
+        {
+          status: 400,
+          headers: createResponseHeaders(),
+        },
+      );
+    }
+
+    logInfo("api_request_started", {
+      route: "auth_check",
+      password_present: typeof password === "string" && password.length > 0,
+    });
+
+    const demoPassword = process.env.DEMO_PASSWORD;
+    if (!demoPassword || password !== demoPassword) {
+      logWarn("auth_check_failed", {
+        route: "auth_check",
+        password_configured: !!demoPassword,
+      });
+      return NextResponse.json(
+        { ok: false },
+        {
+          status: 401,
+          headers: createResponseHeaders(),
+        },
+      );
+    }
+
+    logInfo("auth_check_succeeded", {
+      route: "auth_check",
+    });
+    return NextResponse.json(
+      { ok: true },
+      {
+        headers: createResponseHeaders(),
+      },
+    );
+  });
 }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,4 +1,15 @@
 import { NextResponse } from "next/server";
+import {
+  createRequestContext,
+  createResponseHeaders,
+  logCapabilitySnapshot,
+  logError,
+  logInfo,
+  logWarn,
+  serializeError,
+  updateRequestContext,
+  withRequestContext,
+} from "@/lib/server/app-logger";
 import { checkRateLimit } from "@/lib/server/rate-limit";
 import type { DemoAgentEvent } from "@/lib/server/demo-agent-runner";
 import { getGroundedAgent } from "@/lib/server/grounded-agent";
@@ -71,113 +82,180 @@ function formatToolError(error: unknown): string {
 }
 
 export async function POST(req: Request) {
-  const ip =
-    req.headers.get("x-forwarded-for")?.split(",")[0].trim() ?? "unknown";
-
-  if (!checkRateLimit(ip)) {
-    return NextResponse.json({ error: "Rate limit exceeded" }, { status: 429 });
-  }
-
-  const body = (await req.json()) as ChatRequestBody;
-  const model = body.model ?? "gpt-5.4-mini-2026-03-17";
-  const provider = body.provider ?? "openai";
-  const agentMode = body.agentMode ?? "ungrounded";
-  const messages = normalizeMessages(body);
-
-  if (messages.length === 0) {
-    return NextResponse.json(
-      { error: "A prompt is required." },
-      { status: 400 },
-    );
-  }
-
-  if (isPlaywrightTestMode()) {
-    return createPlaywrightMockChatResponse({
-      agentMode,
-      prompt: messages.at(-1)?.content ?? body.prompt ?? "",
-    });
-  }
-
-  try {
-    assertProviderIsConfigured(provider);
-  } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Provider not configured.";
-    return NextResponse.json({ error: message }, { status: 503 });
-  }
-
-  const startMs = Date.now();
-  const agent =
-    agentMode === "grounded"
-      ? getGroundedAgent({ model, provider })
-      : getUngroundedAgent({ model, provider });
-  const backendLabel = getDemoPanelConfigs(provider)[agentMode].backendLabel;
-
-  console.log(
-    JSON.stringify({
-      event: "request_start",
-      route: "chat",
-      backend: backendLabel,
-      agent_mode: agentMode,
-      provider,
-      model,
-      timestamp: new Date().toISOString(),
-    }),
-  );
-
-  const stream = new ReadableStream({
-    async start(controller) {
-      try {
-        const eventStream = agent.streamResponse({
-          messages,
-          signal: req.signal,
-        });
-
-        for await (const event of eventStream) {
-          handleAgentEvent(controller, event);
-        }
-
-        controller.enqueue(encodeDone());
-
-        console.log(
-          JSON.stringify({
-            event: "request_complete",
-            route: "chat",
-            backend: backendLabel,
-            agent_mode: agentMode,
-            provider,
-            model,
-            total_ms: Date.now() - startMs,
-          }),
-        );
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Internal streaming error.";
-        controller.enqueue(encodeError(message));
-
-        console.error(
-          JSON.stringify({
-            event: "request_error",
-            route: "chat",
-            backend: backendLabel,
-            agent_mode: agentMode,
-            provider,
-            model,
-            message,
-          }),
-        );
-      } finally {
-        controller.close();
-      }
-    },
+  const requestContext = createRequestContext(req, {
+    route: "chat",
+    method: "POST",
   });
 
-  return new Response(stream, {
-    headers: {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
-      "X-Vercel-AI-Data-Stream": "v1",
-    },
+  return withRequestContext(requestContext, async () => {
+    const ip =
+      req.headers.get("x-forwarded-for")?.split(",")[0].trim() ?? "unknown";
+    if (!checkRateLimit(ip)) {
+      logWarn("api_request_rate_limited", {
+        route: "chat",
+        forwarded_for_present: req.headers.has("x-forwarded-for"),
+      });
+      return NextResponse.json(
+        { error: "Rate limit exceeded" },
+        {
+          status: 429,
+          headers: createResponseHeaders(),
+        },
+      );
+    }
+
+    let body: ChatRequestBody;
+    try {
+      body = (await req.json()) as ChatRequestBody;
+    } catch (error) {
+      logWarn("api_request_invalid_json", {
+        route: "chat",
+        error: serializeError(error),
+      });
+      return NextResponse.json(
+        { error: "Request body must be valid JSON." },
+        {
+          status: 400,
+          headers: createResponseHeaders(),
+        },
+      );
+    }
+
+    const model = body.model ?? "gpt-5.4-mini-2026-03-17";
+    const provider = body.provider ?? "openai";
+    const agentMode = body.agentMode ?? "ungrounded";
+    const messages = normalizeMessages(body);
+    const openAIConfigured =
+      provider === "openai" &&
+      (isPlaywrightTestMode() || !!process.env.OPENAI_API_KEY);
+    const panelConfig = getDemoPanelConfigs(provider, {
+      openAIConfigured,
+    })[agentMode];
+    const backendLabel = panelConfig.backendLabel;
+
+    updateRequestContext({
+      provider,
+      agentMode,
+      model,
+      backend: backendLabel,
+    });
+
+    logInfo("api_request_started", {
+      route: "chat",
+      backend: backendLabel,
+      provider,
+      model,
+      agent_mode: agentMode,
+      message_count: messages.length,
+      last_user_message_chars: messages.at(-1)?.content.length ?? 0,
+    });
+    logCapabilitySnapshot({
+      provider,
+      agentMode,
+      backend: backendLabel,
+      capabilities: panelConfig.capabilities,
+    });
+
+    if (messages.length === 0) {
+      logWarn("api_request_rejected", {
+        route: "chat",
+        reason: "missing_prompt",
+      });
+      return NextResponse.json(
+        { error: "A prompt is required." },
+        {
+          status: 400,
+          headers: createResponseHeaders(),
+        },
+      );
+    }
+
+    if (isPlaywrightTestMode()) {
+      logInfo("api_request_mocked", {
+        route: "chat",
+        backend: "playwright-mock",
+        agent_mode: agentMode,
+      });
+      return createPlaywrightMockChatResponse({
+        agentMode,
+        prompt: messages.at(-1)?.content ?? body.prompt ?? "",
+        headers: createResponseHeaders(),
+      });
+    }
+
+    try {
+      assertProviderIsConfigured(provider);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Provider not configured.";
+      logWarn("api_request_provider_unavailable", {
+        route: "chat",
+        provider,
+        error: serializeError(error),
+      });
+      return NextResponse.json(
+        { error: message },
+        {
+          status: 503,
+          headers: createResponseHeaders(),
+        },
+      );
+    }
+
+    const startMs = Date.now();
+    const agent =
+      agentMode === "grounded"
+        ? getGroundedAgent({ model, provider })
+        : getUngroundedAgent({ model, provider });
+
+    const stream = new ReadableStream({
+      async start(controller) {
+        try {
+          const eventStream = agent.streamResponse({
+            messages,
+            signal: req.signal,
+          });
+
+          for await (const event of eventStream) {
+            handleAgentEvent(controller, event);
+          }
+
+          controller.enqueue(encodeDone());
+
+          logInfo("api_request_completed", {
+            route: "chat",
+            backend: backendLabel,
+            provider,
+            model,
+            agent_mode: agentMode,
+            duration_ms: Date.now() - startMs,
+          });
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "Internal streaming error.";
+          controller.enqueue(encodeError(message));
+          logError("api_request_failed", {
+            route: "chat",
+            backend: backendLabel,
+            provider,
+            model,
+            agent_mode: agentMode,
+            duration_ms: Date.now() - startMs,
+            error: serializeError(error),
+          });
+        } finally {
+          controller.close();
+        }
+      },
+    });
+
+    return new Response(stream, {
+      headers: createResponseHeaders({
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "X-Vercel-AI-Data-Stream": "v1",
+      }),
+    });
   });
 }
 
@@ -191,6 +269,11 @@ function handleAgentEvent(
   }
 
   if (event.type === "tool-start") {
+    logInfo("tool_call_started", {
+      tool_call_id: event.toolCallId,
+      tool_name: event.toolName,
+      args: event.args,
+    });
     controller.enqueue(
       encodeMetadata({
         type: "tool-start",
@@ -203,6 +286,11 @@ function handleAgentEvent(
   }
 
   if (event.type === "tool-end") {
+    logInfo("tool_call_completed", {
+      tool_call_id: event.toolCallId,
+      tool_name: event.toolName,
+      result: event.result,
+    });
     controller.enqueue(
       encodeMetadata({
         type: "tool-end",
@@ -214,6 +302,11 @@ function handleAgentEvent(
     return;
   }
 
+  logWarn("tool_call_failed", {
+    tool_call_id: event.toolCallId,
+    tool_name: event.toolName,
+    error: event.error,
+  });
   controller.enqueue(
     encodeMetadata({
       type: "tool-error",

--- a/app/api/config/route.ts
+++ b/app/api/config/route.ts
@@ -1,21 +1,75 @@
 import { NextResponse } from "next/server";
-import { getPublicDemoConfig } from "@/lib/server/demo-config";
+import {
+  createRequestContext,
+  createResponseHeaders,
+  logCapabilitySnapshot,
+  logInfo,
+  updateRequestContext,
+  withRequestContext,
+} from "@/lib/server/app-logger";
+import {
+  getDemoPanelConfigs,
+  getPublicDemoConfig,
+} from "@/lib/server/demo-config";
 import { isPlaywrightTestMode } from "@/lib/server/playwright-mock-chat";
 
 export const runtime = "nodejs";
 
 export async function GET(req: Request) {
-  const { searchParams } = new URL(req.url);
-  const provider = searchParams.get("provider") === "anthropic"
-    ? "anthropic"
-    : "openai";
-  const openAIConfigured =
-    provider === "openai" &&
-    (isPlaywrightTestMode() || !!process.env.OPENAI_API_KEY);
+  const requestContext = createRequestContext(req, {
+    route: "config",
+    method: "GET",
+  });
 
-  return NextResponse.json({
-    ...getPublicDemoConfig(provider, { openAIConfigured }),
-    openaiAvailable: openAIConfigured,
-    anthropicAvailable: !!process.env.ANTHROPIC_API_KEY,
+  return withRequestContext(requestContext, async () => {
+    const { searchParams } = new URL(req.url);
+    const provider = searchParams.get("provider") === "anthropic"
+      ? "anthropic"
+      : "openai";
+    const openAIConfigured =
+      provider === "openai" &&
+      (isPlaywrightTestMode() || !!process.env.OPENAI_API_KEY);
+    const anthropicAvailable = !!process.env.ANTHROPIC_API_KEY;
+    const panelConfigs = getDemoPanelConfigs(provider, {
+      openAIConfigured,
+    });
+
+    updateRequestContext({ provider });
+    logInfo("api_request_started", {
+      route: "config",
+      provider,
+      openai_available: openAIConfigured,
+      anthropic_available: anthropicAvailable,
+    });
+    logCapabilitySnapshot({
+      provider,
+      agentMode: "ungrounded",
+      backend: panelConfigs.ungrounded.backendLabel,
+      capabilities: panelConfigs.ungrounded.capabilities,
+    });
+    logCapabilitySnapshot({
+      provider,
+      agentMode: "grounded",
+      backend: panelConfigs.grounded.backendLabel,
+      capabilities: panelConfigs.grounded.capabilities,
+    });
+
+    logInfo("api_request_completed", {
+      route: "config",
+      provider,
+      openai_available: openAIConfigured,
+      anthropic_available: anthropicAvailable,
+    });
+
+    return NextResponse.json(
+      {
+        ...getPublicDemoConfig(provider, { openAIConfigured }),
+        openaiAvailable: openAIConfigured,
+        anthropicAvailable,
+      },
+      {
+        headers: createResponseHeaders(),
+      },
+    );
   });
 }

--- a/docs/AWS_DEPLOYMENT.md
+++ b/docs/AWS_DEPLOYMENT.md
@@ -35,6 +35,7 @@
 npm install
 npm run lint
 npm run typecheck
+npm test
 DEMO_PASSWORD=test OPENAI_API_KEY=test npm run build
 ```
 
@@ -56,4 +57,6 @@ Only these application secrets are injected:
 ## Notes
 
 - Anthropic is optional at deploy time. The UI exposes Claude models, but the backend returns a clear configuration error if the key is missing.
-- The current slice intentionally does not mount code-execution, search, or file capabilities.
+- OpenAI-backed dev/prod deploys emit structured JSON logs with request IDs, trace IDs, capability snapshots, tool activity, and model-run summaries. See [`docs/LOGGING.md`](/home/jack/workspace/supplie-demo-issue5/docs/LOGGING.md).
+- On successful deploys, the workflows print recent app logs with `kubectl logs deployment/supplie-demo -n <namespace> --tail=80`.
+- On deploy failures, the workflows run `scripts/collect-k8s-diagnostics.sh` to capture rollout state, pod descriptions, current and previous pod logs, services, ingress, and recent events.

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -1,0 +1,75 @@
+# Structured Logging
+
+The app emits structured JSON logs to stdout/stderr so local runs, dev EKS pods, and GitHub Actions deploy jobs can all be inspected with the same fields.
+
+## What Is Logged
+
+- Every API request logs `api_request_started` and either `api_request_completed`, `api_request_failed`, `api_request_rejected`, or `api_request_rate_limited`.
+- Every model execution logs `model_run_started` and either `model_run_completed` or `model_run_failed`.
+- Tool usage logs `tool_call_started`, `tool_call_completed`, and `tool_call_failed`.
+- Capability state logs `capability_snapshot` with `supported_capabilities` and `unsupported_capabilities`.
+- OpenAI bundle/bootstrap paths log whether the shared file/vector-store bundle was reused, created, or failed.
+
+Each log line includes:
+
+- `timestamp`
+- `service`
+- `level`
+- `event`
+- `requestId`
+- `traceId`
+- request context such as `route`, `method`, `provider`, `agentMode`, `model`, and `backend` when available
+
+## Request And Trace IDs
+
+- Incoming `x-request-id`, `x-correlation-id`, `traceparent`, `x-trace-id`, and `x-b3-traceid` headers are reused when present.
+- If no IDs are supplied, the server generates them.
+- API responses include `X-Request-Id` and `X-Trace-Id` headers so callers can correlate client failures with server logs.
+
+## Redaction Rules
+
+- Keys containing `api_key`, `authorization`, `cookie`, `credential`, `password`, `secret`, or `token` are logged as `[REDACTED]`.
+- Known token formats such as `Bearer ...`, `sk-...`, `sk-ant-...`, and GitHub personal access token prefixes are redacted even when they appear inside larger payloads.
+- Request logs avoid raw prompt bodies and passwords. They log counts, sizes, and capability state instead.
+
+## Local Usage
+
+Run the app normally:
+
+```bash
+npm install
+export DEMO_PASSWORD=local-demo-password
+export OPENAI_API_KEY=sk-...
+npm run dev
+```
+
+Then inspect logs:
+
+```bash
+npm run dev | jq
+```
+
+If `jq` is not installed, plain stdout still contains one JSON object per line.
+
+## Dev EKS Usage
+
+Recent logs from the dev deployment:
+
+```bash
+kubectl logs deployment/supplie-demo -n supplie-dev --tail=80
+```
+
+Filter to a specific request or trace:
+
+```bash
+kubectl logs deployment/supplie-demo -n supplie-dev | jq 'select(.requestId=="<request-id>")'
+kubectl logs deployment/supplie-demo -n supplie-dev | jq 'select(.traceId=="<trace-id>")'
+```
+
+## Deploy Diagnostics
+
+Both GitHub Actions deploy workflows now:
+
+- print a small cluster snapshot after kubeconfig setup
+- print recent application logs after a successful rollout
+- collect `kubectl describe`, pod logs, previous pod logs, services, ingress, and events on failure with `scripts/collect-k8s-diagnostics.sh`

--- a/k8s/supplie-deployment.yaml
+++ b/k8s/supplie-deployment.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
         - name: supplie-demo
           image: SUPPLIE_IMAGE  # replaced by CI/CD
+          terminationMessagePolicy: FallbackToLogsOnError
           ports:
             - containerPort: 3000
           env:
@@ -39,6 +40,10 @@ spec:
                   key: DEMO_PASSWORD
             - name: NODE_ENV
               value: "production"
+            - name: LOG_LEVEL
+              value: "info"
+            - name: LOG_FORMAT
+              value: "json"
           readinessProbe:
             httpGet:
               path: /api/config

--- a/lib/server/app-logger.test.ts
+++ b/lib/server/app-logger.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createRequestContext,
+  createResponseHeaders,
+  getRequestContext,
+  sanitizeForLogs,
+  summarizeCapabilities,
+  updateRequestContext,
+  withRequestContext,
+} from "./app-logger.ts";
+import type { DemoCapability } from "./demo-capabilities.ts";
+
+test("createRequestContext preserves inbound ids when present", () => {
+  const request = new Request("https://example.com/api/chat", {
+    method: "POST",
+    headers: {
+      "x-request-id": "req-123",
+      traceparent: "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
+    },
+  });
+
+  const context = createRequestContext(request, {
+    route: "chat",
+    method: "POST",
+  });
+
+  assert.equal(context.requestId, "req-123");
+  assert.equal(context.traceId, "1234567890abcdef1234567890abcdef");
+  assert.equal(context.route, "chat");
+  assert.equal(context.method, "POST");
+});
+
+test("request context updates flow into response headers", async () => {
+  const request = new Request("https://example.com/api/config", {
+    method: "GET",
+  });
+  const context = createRequestContext(request, {
+    route: "config",
+    method: "GET",
+  });
+
+  await withRequestContext(context, async () => {
+    updateRequestContext({
+      provider: "openai",
+    });
+
+    assert.equal(getRequestContext()?.provider, "openai");
+    const headers = createResponseHeaders();
+    assert.equal(headers.get("X-Request-Id"), context.requestId);
+    assert.equal(headers.get("X-Trace-Id"), context.traceId);
+  });
+});
+
+test("sanitizeForLogs redacts secrets recursively", () => {
+  const sanitized = sanitizeForLogs({
+    apiKey: "sk-secret-value",
+    nested: {
+      authorization: "Bearer abc123",
+      safe: "plain-text",
+    },
+    array: ["sk-ant-secret-value", "keep-me"],
+  }) as {
+    apiKey: string;
+    nested: { authorization: string; safe: string };
+    array: string[];
+  };
+
+  assert.equal(sanitized.apiKey, "[REDACTED]");
+  assert.equal(sanitized.nested.authorization, "[REDACTED]");
+  assert.equal(sanitized.nested.safe, "plain-text");
+  assert.equal(sanitized.array[0], "[REDACTED]");
+  assert.equal(sanitized.array[1], "keep-me");
+});
+
+test("summarizeCapabilities splits enabled and disabled capability ids", () => {
+  const capabilities: DemoCapability[] = [
+    {
+      id: "streaming_text",
+      label: "Streaming responses",
+      enabled: true,
+      availability: "available",
+      description: "Streaming is enabled.",
+    },
+    {
+      id: "live_systems",
+      label: "Live systems",
+      enabled: false,
+      availability: "planned",
+      description: "Live systems are not enabled.",
+    },
+  ];
+
+  assert.deepEqual(summarizeCapabilities(capabilities), {
+    supported: ["streaming_text"],
+    unsupported: ["live_systems"],
+  });
+});

--- a/lib/server/app-logger.ts
+++ b/lib/server/app-logger.ts
@@ -1,0 +1,249 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomUUID } from "node:crypto";
+import type { DemoCapability } from "./demo-capabilities";
+import type { DemoAgentMode, DemoProvider } from "./demo-config";
+
+export interface RequestLogContext {
+  requestId: string;
+  traceId: string;
+  route: string;
+  method: string;
+  provider?: DemoProvider;
+  agentMode?: DemoAgentMode;
+  model?: string;
+  backend?: string;
+}
+
+const requestContextStore = new AsyncLocalStorage<RequestLogContext>();
+const SENSITIVE_KEY_PATTERN =
+  /(api[-_]?key|authorization|cookie|credential|password|secret|set-cookie|token)/i;
+const TOKEN_VALUE_PATTERNS = [
+  /Bearer\s+[A-Za-z0-9._-]+/gi,
+  /gh[pousr]_[A-Za-z0-9_]{8,}/g,
+  /sk-[A-Za-z0-9_-]{8,}/g,
+  /sk-ant-[A-Za-z0-9_-]{8,}/g,
+];
+const MAX_STRING_LENGTH = 320;
+const MAX_ITEMS = 20;
+
+function newTraceId() {
+  return randomUUID().replaceAll("-", "");
+}
+
+function parseTraceId(value: string | null) {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (/^[0-9a-f]{32}$/i.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+
+  const traceparentMatch = trimmed.match(
+    /^[0-9a-f]{2}-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$/i,
+  );
+  if (traceparentMatch) {
+    return traceparentMatch[1].toLowerCase();
+  }
+
+  return null;
+}
+
+function truncate(value: string) {
+  if (value.length <= MAX_STRING_LENGTH) {
+    return value;
+  }
+
+  return `${value.slice(0, MAX_STRING_LENGTH)}...<truncated>`;
+}
+
+function redactSensitiveString(value: string) {
+  return TOKEN_VALUE_PATTERNS.reduce(
+    (result, pattern) => result.replace(pattern, "[REDACTED]"),
+    value,
+  );
+}
+
+function sanitizeValue(
+  value: unknown,
+  keyHint?: string,
+  depth = 0,
+): unknown {
+  if (value == null || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    if (keyHint && SENSITIVE_KEY_PATTERN.test(keyHint)) {
+      return "[REDACTED]";
+    }
+
+    return truncate(redactSensitiveString(value));
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: sanitizeValue(value.message),
+      stack: sanitizeValue(value.stack ?? ""),
+    };
+  }
+
+  if (depth >= 4) {
+    return "[Truncated]";
+  }
+
+  if (Array.isArray(value)) {
+    return value.slice(0, MAX_ITEMS).map((item) =>
+      sanitizeValue(item, keyHint, depth + 1)
+    );
+  }
+
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).slice(0, MAX_ITEMS).map(([key, entryValue]) => [
+        key,
+        sanitizeValue(entryValue, key, depth + 1),
+      ]),
+    );
+  }
+
+  return String(value);
+}
+
+function writeLog(
+  level: "info" | "warn" | "error",
+  event: string,
+  data?: Record<string, unknown>,
+) {
+  const context = requestContextStore.getStore();
+  const entry = {
+    timestamp: new Date().toISOString(),
+    service: "supplie-demo",
+    level,
+    event,
+    ...context,
+    ...(sanitizeValue(data) as Record<string, unknown> | undefined),
+  };
+
+  const serialized = JSON.stringify(entry);
+  if (level === "error") {
+    console.error(serialized);
+    return;
+  }
+
+  if (level === "warn") {
+    console.warn(serialized);
+    return;
+  }
+
+  console.log(serialized);
+}
+
+export function createRequestContext(
+  request: Request,
+  overrides: Pick<RequestLogContext, "route" | "method"> &
+    Partial<
+      Omit<RequestLogContext, "requestId" | "traceId" | "route" | "method">
+    >,
+): RequestLogContext {
+  const requestId =
+    request.headers.get("x-request-id")?.trim() ||
+    request.headers.get("x-correlation-id")?.trim() ||
+    randomUUID();
+  const traceId =
+    parseTraceId(request.headers.get("traceparent")) ||
+    parseTraceId(request.headers.get("x-trace-id")) ||
+    parseTraceId(request.headers.get("x-b3-traceid")) ||
+    newTraceId();
+
+  return {
+    requestId,
+    traceId,
+    ...overrides,
+  };
+}
+
+export function withRequestContext<T>(
+  context: RequestLogContext,
+  fn: () => Promise<T> | T,
+) {
+  return requestContextStore.run(context, fn);
+}
+
+export function updateRequestContext(updates: Partial<RequestLogContext>) {
+  const context = requestContextStore.getStore();
+  if (!context) {
+    return;
+  }
+
+  Object.assign(context, updates);
+}
+
+export function getRequestContext() {
+  return requestContextStore.getStore();
+}
+
+export function createResponseHeaders(init?: HeadersInit) {
+  const headers = new Headers(init);
+  const context = getRequestContext();
+  if (context) {
+    headers.set("X-Request-Id", context.requestId);
+    headers.set("X-Trace-Id", context.traceId);
+  }
+
+  return headers;
+}
+
+export function serializeError(error: unknown) {
+  if (error instanceof Error) {
+    return sanitizeValue(error);
+  }
+
+  return sanitizeValue(String(error));
+}
+
+export function summarizeCapabilities(capabilities: DemoCapability[]) {
+  return {
+    supported: capabilities
+      .filter((capability) => capability.enabled)
+      .map((capability) => capability.id),
+    unsupported: capabilities
+      .filter((capability) => !capability.enabled)
+      .map((capability) => capability.id),
+  };
+}
+
+export function logCapabilitySnapshot(options: {
+  provider: DemoProvider;
+  agentMode: DemoAgentMode;
+  backend: string;
+  capabilities: DemoCapability[];
+}) {
+  const summary = summarizeCapabilities(options.capabilities);
+
+  writeLog("info", "capability_snapshot", {
+    provider: options.provider,
+    agent_mode: options.agentMode,
+    backend: options.backend,
+    supported_capabilities: summary.supported,
+    unsupported_capabilities: summary.unsupported,
+  });
+}
+
+export function logInfo(event: string, data?: Record<string, unknown>) {
+  writeLog("info", event, data);
+}
+
+export function logWarn(event: string, data?: Record<string, unknown>) {
+  writeLog("warn", event, data);
+}
+
+export function logError(event: string, data?: Record<string, unknown>) {
+  writeLog("error", event, data);
+}
+
+export function sanitizeForLogs(value: unknown) {
+  return sanitizeValue(value);
+}

--- a/lib/server/chat-model.test.ts
+++ b/lib/server/chat-model.test.ts
@@ -2,8 +2,6 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { ChatOpenAI } from "@langchain/openai";
-// Node's built-in test runner needs the explicit .ts suffix here.
-// @ts-expect-error TypeScript does not allow TS extensions without allowImportingTsExtensions.
 import { getChatModel } from "./chat-model.ts";
 
 test("getChatModel returns a concrete OpenAI chat model instance", () => {

--- a/lib/server/demo-agent-runner.ts
+++ b/lib/server/demo-agent-runner.ts
@@ -5,6 +5,12 @@ import {
   SystemMessage,
   ToolMessage,
 } from "@langchain/core/messages";
+import {
+  logError,
+  logInfo,
+  serializeError,
+} from "./app-logger.ts";
+import type { DemoAgentMode, DemoProvider } from "./demo-config";
 
 export interface DemoRequestMessage {
   role: "user" | "assistant";
@@ -52,6 +58,13 @@ export interface DemoAgent {
   streamResponse(
     options: DemoAgentOptions,
   ): AsyncGenerator<DemoAgentEvent, void, void>;
+}
+
+export interface DemoAgentInstrumentationOptions {
+  backend: string;
+  provider: DemoProvider;
+  model: string;
+  agentMode: DemoAgentMode;
 }
 
 interface DemoTool {
@@ -267,6 +280,79 @@ export function createToolAgent(options: {
       throw new Error(
         "Grounded agent exceeded the maximum number of tool iterations.",
       );
+    },
+  };
+}
+
+export function instrumentDemoAgent(
+  agent: DemoAgent,
+  metadata: DemoAgentInstrumentationOptions,
+): DemoAgent {
+  return {
+    async *streamResponse(options) {
+      const startedAt = Date.now();
+      const eventCounts = {
+        text_delta: 0,
+        tool_start: 0,
+        tool_end: 0,
+        tool_error: 0,
+      };
+      const toolNames = new Set<string>();
+
+      logInfo("model_run_started", {
+        backend: metadata.backend,
+        provider: metadata.provider,
+        model: metadata.model,
+        agent_mode: metadata.agentMode,
+        message_count: options.messages.length,
+      });
+
+      try {
+        for await (const event of agent.streamResponse(options)) {
+          if (event.type === "text-delta") {
+            eventCounts.text_delta += 1;
+          }
+
+          if (event.type === "tool-start") {
+            eventCounts.tool_start += 1;
+            toolNames.add(event.toolName);
+          }
+
+          if (event.type === "tool-end") {
+            eventCounts.tool_end += 1;
+            toolNames.add(event.toolName);
+          }
+
+          if (event.type === "tool-error") {
+            eventCounts.tool_error += 1;
+            toolNames.add(event.toolName);
+          }
+
+          yield event;
+        }
+
+        logInfo("model_run_completed", {
+          backend: metadata.backend,
+          provider: metadata.provider,
+          model: metadata.model,
+          agent_mode: metadata.agentMode,
+          duration_ms: Date.now() - startedAt,
+          event_counts: eventCounts,
+          tool_names: [...toolNames],
+        });
+      } catch (error) {
+        logError("model_run_failed", {
+          backend: metadata.backend,
+          provider: metadata.provider,
+          model: metadata.model,
+          agent_mode: metadata.agentMode,
+          duration_ms: Date.now() - startedAt,
+          event_counts: eventCounts,
+          tool_names: [...toolNames],
+          error: serializeError(error),
+        });
+        throw error;
+      }
     },
   };
 }

--- a/lib/server/demo-capabilities.test.ts
+++ b/lib/server/demo-capabilities.test.ts
@@ -1,6 +1,5 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-// @ts-expect-error TypeScript does not allow TS extensions without allowImportingTsExtensions.
 import { getGroundedCapabilities, getUngroundedCapabilities } from "./demo-capabilities.ts";
 
 function enabledCapabilityIds(

--- a/lib/server/grounded-agent.ts
+++ b/lib/server/grounded-agent.ts
@@ -7,7 +7,11 @@ import {
 } from "./demo-capabilities";
 import type { DemoProvider } from "./demo-config";
 import { getChatModel } from "./chat-model";
-import { createToolAgent } from "./demo-agent-runner";
+import {
+  createToolAgent,
+  instrumentDemoAgent,
+  type DemoAgent,
+} from "./demo-agent-runner";
 import { createOpenAINativeGroundedAgent } from "./openai-native-grounded-agent";
 
 interface GroundedAgentOptions {
@@ -15,7 +19,7 @@ interface GroundedAgentOptions {
   provider: DemoProvider;
 }
 
-const agentCache = new Map<string, ReturnType<typeof createToolAgent>>();
+const agentCache = new Map<string, DemoAgent>();
 
 function buildAnthropicGroundedSystemPrompt(): string {
   return [
@@ -38,7 +42,7 @@ export function getGroundedAgent(options: GroundedAgentOptions) {
     return cached;
   }
 
-  const agent =
+  const baseAgent =
     options.provider === "openai"
       ? createOpenAINativeGroundedAgent(options.model)
       : createToolAgent({
@@ -46,6 +50,15 @@ export function getGroundedAgent(options: GroundedAgentOptions) {
           tools: [...annonaGroundedTools],
           systemPrompt: buildAnthropicGroundedSystemPrompt(),
         });
+  const agent = instrumentDemoAgent(baseAgent, {
+    backend:
+      options.provider === "openai"
+        ? "OpenAI Responses grounded Annona agent"
+        : "Annona grounded demo agent",
+    provider: options.provider,
+    model: options.model,
+    agentMode: "grounded",
+  });
 
   agentCache.set(cacheKey, agent);
   return agent;

--- a/lib/server/openai-native-bundle.test.ts
+++ b/lib/server/openai-native-bundle.test.ts
@@ -1,9 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
-// @ts-expect-error TypeScript does not allow TS extensions without allowImportingTsExtensions.
 import { ANNONA_DEMO_SNAPSHOT } from "./annona-grounded-tools.ts";
-// @ts-expect-error TypeScript does not allow TS extensions without allowImportingTsExtensions.
 import { SHARED_OPENAI_NATIVE_FILES } from "./openai-native-bundle.ts";
 
 interface CsvOrderRow {

--- a/lib/server/openai-native-bundle.ts
+++ b/lib/server/openai-native-bundle.ts
@@ -1,6 +1,11 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import OpenAI, { toFile } from "openai";
+import {
+  logError,
+  logInfo,
+  serializeError,
+} from "./app-logger.ts";
 
 const SHARED_BUNDLE_ID = "supplie-demo-openai-native-shared-bundle-v2";
 const SHARED_VECTOR_STORE_NAME = "supplie-demo-openai-native-reference-files";
@@ -82,9 +87,17 @@ async function waitForVectorStoreReady(
   client: OpenAI,
   vectorStoreId: string,
 ): Promise<void> {
+  logInfo("openai_bundle_vector_store_wait_started", {
+    vector_store_id: vectorStoreId,
+  });
+
   for (let attempt = 0; attempt < 60; attempt += 1) {
     const vectorStore = await client.vectorStores.retrieve(vectorStoreId);
     if (vectorStore.status === "completed") {
+      logInfo("openai_bundle_vector_store_ready", {
+        vector_store_id: vectorStoreId,
+        attempts: attempt + 1,
+      });
       return;
     }
 
@@ -97,6 +110,9 @@ async function waitForVectorStoreReady(
 async function findExistingBundle(
   client: OpenAI,
 ): Promise<PreparedOpenAIBundle | null> {
+  logInfo("openai_bundle_lookup_started", {
+    expected_bundle_id: SHARED_BUNDLE_ID,
+  });
   const vectorStores = await client.vectorStores.list({ limit: 100 });
   const existing = vectorStores.data.find(
     (store) => store.metadata?.bundle_id === SHARED_BUNDLE_ID,
@@ -131,10 +147,17 @@ async function findExistingBundle(
 async function createBundledFiles(
   client: OpenAI,
 ): Promise<PreparedOpenAIBundle> {
+  logInfo("openai_bundle_creation_started", {
+    file_count: SHARED_OPENAI_NATIVE_FILES.length,
+    bundle_id: SHARED_BUNDLE_ID,
+  });
   const uploadedFiles = await Promise.all(
     SHARED_OPENAI_NATIVE_FILES.map(async (file) => {
       const contents = await readFile(file.absolutePath);
 
+      logInfo("openai_bundle_file_upload_started", {
+        file_name: file.fileName,
+      });
       const uploaded = await client.files.create({
         file: await toFile(contents, file.fileName),
         purpose: "assistants",
@@ -145,6 +168,10 @@ async function createBundledFiles(
         maxWait: 120000,
       });
 
+      logInfo("openai_bundle_file_ready", {
+        file_name: file.fileName,
+        file_id: uploaded.id,
+      });
       return uploaded;
     }),
   );
@@ -173,12 +200,24 @@ export async function prepareOpenAIBundle(): Promise<PreparedOpenAIBundle> {
       const client = getOpenAIClient();
       const existing = await findExistingBundle(client);
       if (existing) {
+        logInfo("openai_bundle_reused", {
+          vector_store_id: existing.vectorStoreId,
+          file_count: existing.fileIds.length,
+        });
         return existing;
       }
 
-      return createBundledFiles(client);
+      const created = await createBundledFiles(client);
+      logInfo("openai_bundle_ready", {
+        vector_store_id: created.vectorStoreId,
+        file_count: created.fileIds.length,
+      });
+      return created;
     })().catch((error) => {
       preparedBundlePromise = null;
+      logError("openai_bundle_failed", {
+        error: serializeError(error),
+      });
       throw error;
     });
   }

--- a/lib/server/openai-native-grounded-agent.ts
+++ b/lib/server/openai-native-grounded-agent.ts
@@ -22,6 +22,7 @@ import {
   toInputMessages,
   type ResponseCreateResult,
 } from "./openai-responses-utils";
+import { logInfo } from "./app-logger.ts";
 
 const MAX_TOOL_TURNS = 6;
 
@@ -54,6 +55,18 @@ export function createOpenAINativeGroundedAgent(model: string): DemoAgent {
     async *streamResponse({ messages, signal }) {
       const client = getOpenAIClient();
       const bundle = await prepareOpenAIBundle();
+      logInfo("openai_response_request_started", {
+        agent_mode: "grounded",
+        model,
+        turn: 0,
+        tool_types: [
+          "web_search_preview",
+          "file_search",
+          "code_interpreter",
+          "annona_function_tools",
+        ],
+        input_messages: messages.length,
+      });
 
       let response = (await client.responses.create(
         {
@@ -93,6 +106,14 @@ export function createOpenAINativeGroundedAgent(model: string): DemoAgent {
         } as any,
         { signal },
       )) as ResponseCreateResult;
+      logInfo("openai_response_received", {
+        agent_mode: "grounded",
+        model,
+        turn: 0,
+        response_id: response.id ?? null,
+        output_items: response.output?.length ?? 0,
+        function_call_count: getResponseFunctionCalls(response).length,
+      });
 
       for (let turn = 0; turn < MAX_TOOL_TURNS; turn += 1) {
         for (const event of responseToDemoAgentEvents(response)) {
@@ -184,6 +205,14 @@ export function createOpenAINativeGroundedAgent(model: string): DemoAgent {
           } as any,
           { signal },
         )) as ResponseCreateResult;
+        logInfo("openai_response_received", {
+          agent_mode: "grounded",
+          model,
+          turn: turn + 1,
+          response_id: response.id ?? null,
+          output_items: response.output?.length ?? 0,
+          function_call_count: getResponseFunctionCalls(response).length,
+        });
       }
 
       throw new Error("Grounded OpenAI agent exceeded the tool iteration limit.");

--- a/lib/server/openai-native-ungrounded-agent.ts
+++ b/lib/server/openai-native-ungrounded-agent.ts
@@ -11,10 +11,12 @@ import {
   SHARED_OPENAI_NATIVE_FILES,
 } from "./openai-native-bundle";
 import {
+  getResponseFunctionCalls,
   responseToDemoAgentEvents,
   toInputMessages,
   type ResponseCreateResult,
 } from "./openai-responses-utils";
+import { logInfo } from "./app-logger.ts";
 
 export function buildOpenAINativeUngroundedSystemPrompt(): string {
   return [
@@ -43,6 +45,12 @@ export function createOpenAINativeUngroundedAgent(model: string): DemoAgent {
     async *streamResponse({ messages, signal }) {
       const client = getOpenAIClient();
       const bundle = await prepareOpenAIBundle();
+      logInfo("openai_response_request_started", {
+        agent_mode: "ungrounded",
+        model,
+        tool_types: ["web_search_preview", "file_search", "code_interpreter"],
+        input_messages: messages.length,
+      });
       const response = (await client.responses.create(
         {
           model,
@@ -80,6 +88,13 @@ export function createOpenAINativeUngroundedAgent(model: string): DemoAgent {
         } as any,
         { signal },
       )) as ResponseCreateResult;
+      logInfo("openai_response_received", {
+        agent_mode: "ungrounded",
+        model,
+        response_id: response.id ?? null,
+        output_items: response.output?.length ?? 0,
+        function_call_count: getResponseFunctionCalls(response).length,
+      });
 
       for (const event of responseToDemoAgentEvents(response)) {
         yield event;

--- a/lib/server/playwright-mock-chat.ts
+++ b/lib/server/playwright-mock-chat.ts
@@ -12,6 +12,7 @@ import {
 interface PlaywrightMockChatResponseOptions {
   agentMode: DemoAgentMode;
   prompt: string;
+  headers?: HeadersInit;
 }
 
 function chunkText(value: string, size: number) {
@@ -31,6 +32,7 @@ export function isPlaywrightTestMode() {
 export function createPlaywrightMockChatResponse({
   agentMode,
   prompt,
+  headers,
 }: PlaywrightMockChatResponseOptions) {
   const normalizedPrompt = prompt.trim() || "No prompt provided.";
   const scenario = getDemoScenarioByPrompt(normalizedPrompt);
@@ -79,6 +81,7 @@ export function createPlaywrightMockChatResponse({
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache",
       "X-Vercel-AI-Data-Stream": "v1",
+      ...Object.fromEntries(new Headers(headers).entries()),
     },
   });
 }

--- a/lib/server/ungrounded-agent.ts
+++ b/lib/server/ungrounded-agent.ts
@@ -4,18 +4,20 @@ import {
 } from "./demo-capabilities";
 import type { DemoProvider } from "./demo-config";
 import { getChatModel } from "./chat-model";
-import { createStreamingTextAgent } from "./demo-agent-runner";
+import {
+  createStreamingTextAgent,
+  instrumentDemoAgent,
+  type DemoAgent,
+} from "./demo-agent-runner";
 import { createOpenAINativeUngroundedAgent } from "./openai-native-ungrounded-agent";
+import { logWarn } from "./app-logger.ts";
 
 interface UngroundedAgentOptions {
   model: string;
   provider: DemoProvider;
 }
 
-const agentCache = new Map<
-  string,
-  ReturnType<typeof createStreamingTextAgent>
->();
+const agentCache = new Map<string, DemoAgent>();
 
 function buildSystemPrompt(): string {
   return [
@@ -32,12 +34,20 @@ function buildSystemPrompt(): string {
 
 export function assertProviderIsConfigured(provider: DemoProvider) {
   if (provider === "anthropic" && !process.env.ANTHROPIC_API_KEY) {
+    logWarn("provider_not_configured", {
+      provider,
+      missing_env: "ANTHROPIC_API_KEY",
+    });
     throw new Error(
       "Anthropic API key not configured. Please contact the demo administrator.",
     );
   }
 
   if (provider === "openai" && !process.env.OPENAI_API_KEY) {
+    logWarn("provider_not_configured", {
+      provider,
+      missing_env: "OPENAI_API_KEY",
+    });
     throw new Error(
       "OpenAI API key not configured. Please contact the demo administrator.",
     );
@@ -51,13 +61,22 @@ export function getUngroundedAgent(options: UngroundedAgentOptions) {
     return cached;
   }
 
-  const agent =
+  const baseAgent =
     options.provider === "openai"
       ? createOpenAINativeUngroundedAgent(options.model)
       : createStreamingTextAgent({
           model: getChatModel(options),
           systemPrompt: buildSystemPrompt(),
         });
+  const agent = instrumentDemoAgent(baseAgent, {
+    backend:
+      options.provider === "openai"
+        ? "OpenAI Responses raw agent"
+        : "LangChain ungrounded agent",
+    provider: options.provider,
+    model: options.model,
+    agentMode: "ungrounded",
+  });
 
   agentCache.set(cacheKey, agent);
   return agent;

--- a/scripts/collect-k8s-diagnostics.sh
+++ b/scripts/collect-k8s-diagnostics.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+NAMESPACE="${1:?usage: collect-k8s-diagnostics.sh <namespace> [app-label] [public-service]}"
+APP_LABEL="${2:-supplie-demo}"
+PUBLIC_SERVICE="${3:-supplie-demo-public}"
+
+echo "::group::kubectl current context"
+kubectl config current-context || true
+echo "::endgroup::"
+
+echo "::group::namespace snapshot"
+kubectl get namespace "${NAMESPACE}" -o wide || true
+kubectl get all -n "${NAMESPACE}" -o wide || true
+kubectl get ingress -n "${NAMESPACE}" -o wide || true
+echo "::endgroup::"
+
+echo "::group::deployment describe"
+kubectl describe deployment "${APP_LABEL}" -n "${NAMESPACE}" || true
+echo "::endgroup::"
+
+echo "::group::service describe"
+kubectl describe service "${APP_LABEL}" -n "${NAMESPACE}" || true
+kubectl describe service "${PUBLIC_SERVICE}" -n "${NAMESPACE}" || true
+echo "::endgroup::"
+
+for pod in $(kubectl get pods -n "${NAMESPACE}" -l "app=${APP_LABEL}" -o name 2>/dev/null || true); do
+  echo "::group::${pod} describe"
+  kubectl describe "${pod}" -n "${NAMESPACE}" || true
+  echo "::endgroup::"
+
+  echo "::group::${pod} logs"
+  kubectl logs "${pod}" -n "${NAMESPACE}" --all-containers --tail=200 || true
+  echo "::endgroup::"
+
+  echo "::group::${pod} previous logs"
+  kubectl logs "${pod}" -n "${NAMESPACE}" --all-containers --previous --tail=200 || true
+  echo "::endgroup::"
+done
+
+echo "::group::recent events"
+kubectl get events -n "${NAMESPACE}" --sort-by=.lastTimestamp || \
+  kubectl get events -n "${NAMESPACE}" || true
+echo "::endgroup::"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- add shared request-scoped JSON logging with request/trace IDs, redaction, capability snapshots, tool logs, and model-run summaries
- wire logging through auth/config/chat plus OpenAI bundle/model execution paths and document how to inspect logs locally and in dev EKS
- improve dev/prod deploy diagnostics with cluster snapshots, recent app logs, and reusable kubectl failure collection

## Validation
- npm run lint
- npm run typecheck
- npm test
- DEMO_PASSWORD=test_password OPENAI_API_KEY=test-openai-key ANTHROPIC_API_KEY=test-anthropic-key npm run build

Closes #5