### PR TITLE
Disable automatic production deploy lane

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -1,9 +1,13 @@
-name: Deploy to EKS
+name: Production Deploy to EKS (manual only)
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
+    inputs:
+      confirm_production_deploy:
+        description: Arm the production deploy only after a real production environment exists
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -16,8 +20,22 @@ env:
   PROD_HOST: demo.supplie.ai
 
 jobs:
+  production-not-active:
+    name: Production deploy not active
+    if: ${{ !inputs.confirm_production_deploy }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Explain disabled state
+        run: |
+          echo "## Production deploy not active" >> "$GITHUB_STEP_SUMMARY"
+          echo "- This repository currently operates a dev-only EKS environment." >> "$GITHUB_STEP_SUMMARY"
+          echo "- The production deploy lane is manual-only and disabled by default until a real production cluster, credentials, and rollout path exist." >> "$GITHUB_STEP_SUMMARY"
+          echo "- Re-run this workflow with \`confirm_production_deploy=true\` only after production is intentionally provisioned." >> "$GITHUB_STEP_SUMMARY"
+
   build-and-deploy:
     name: Build → ECR → Deploy
+    if: ${{ inputs.confirm_production_deploy }}
     runs-on: ubuntu-latest
     environment: production
 

--- a/README.md
+++ b/README.md
@@ -52,19 +52,19 @@ npm run build
 
 - OpenClaw critiques the current state, opens or updates GitHub issues, and sequences the next issue to work.
 - Codex executes one GitHub issue at a time on a dedicated `issue-N-*` branch/worktree.
-- Non-trivial changes are expected to ship through the full GitHub loop: local validation, commit, push, PR, review, deploy, and smoke-test.
+- Non-trivial changes are expected to ship through the full GitHub loop: local validation, commit, push, PR, review, dev deploy, and smoke-test.
 - Work is only done when the deployed result still matches the canonical specs and acceptance docs.
 
 ## Logging
 
 - Structured JSON app logs: [`docs/LOGGING.md`](/home/jack/workspace/supplie-demo-issue5/docs/LOGGING.md)
-- API responses include `X-Request-Id` and `X-Trace-Id` so dev/prod requests can be correlated with server logs.
+- API responses include `X-Request-Id` and `X-Trace-Id` so dev requests, and future prod requests once production exists, can be correlated with server logs.
 - Capability state, tool activity, and model-run summaries are logged without printing raw secrets, tokens, or passwords.
 
 ## AWS EKS Deployment
 
-- Dev CI/CD: [`.github/workflows/dev.yml`](/home/jack/workspace/supplie-demo/.github/workflows/dev.yml)
-- Main/prod EKS deploy: [`.github/workflows/deploy-eks.yml`](/home/jack/workspace/supplie-demo/.github/workflows/deploy-eks.yml)
+- Dev CI/CD: [`.github/workflows/dev.yml`](/home/jack/workspace/supplie-demo/.github/workflows/dev.yml) is the only active deployment lane today.
+- Production EKS deploy: [`.github/workflows/deploy-eks.yml`](/home/jack/workspace/supplie-demo/.github/workflows/deploy-eks.yml) is manual-only and disabled by default until a real production environment exists.
 - Kubernetes manifests: [`k8s/`](/home/jack/workspace/supplie-demo/k8s)
 - Notes: [`docs/AWS_DEPLOYMENT.md`](/home/jack/workspace/supplie-demo/docs/AWS_DEPLOYMENT.md)
 - Logging and diagnostics: [`docs/LOGGING.md`](/home/jack/workspace/supplie-demo/docs/LOGGING.md)

--- a/docs/AWS_DEPLOYMENT.md
+++ b/docs/AWS_DEPLOYMENT.md
@@ -9,7 +9,7 @@
 
 ## Required GitHub Config
 
-### Dev workflow
+### Dev workflow (active)
 
 - `AWS_ACCOUNT_ID`
 - `AWS_ACCESS_KEY_ID_DEV`
@@ -21,9 +21,14 @@
 - `DEV_DEMO_HOST`
 - `DEV_ACM_CERT_ARN`
 
-### Main/prod workflow
+### Production workflow (manual-only placeholder)
 
-Set these on the GitHub `production` environment unless you intentionally want repo-wide defaults.
+The repository does not currently operate a real production EKS environment.
+`.github/workflows/deploy-eks.yml` is manual-only and disabled by default so
+normal merges to `main` do not trigger a misleading red production deploy.
+
+Keep these values ready for the future production lane on the GitHub
+`production` environment unless you intentionally want repo-wide defaults.
 
 - `AWS_ACCOUNT_ID`
 - `AWS_ACCESS_KEY_ID`
@@ -62,9 +67,11 @@ Only these application secrets are injected:
 
 ## Notes
 
-- The production workflow validates its AWS credential inputs before deploy. It uses `AWS_DEPLOY_ROLE_ARN` when present, otherwise falls back to `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.
-- The production workflow also requires `EKS_CLUSTER_PROD` and reads it from the GitHub `production` environment variable first, then the same-named secret if needed. The repo’s documented production region remains `us-east-1`.
+- The active deploy path today is the dev workflow in `.github/workflows/dev.yml`.
+- The production workflow only runs through `workflow_dispatch`, and only when `confirm_production_deploy=true` is explicitly supplied after a real production environment exists.
+- When production is eventually armed, the workflow validates its AWS credential inputs before deploy. It uses `AWS_DEPLOY_ROLE_ARN` when present, otherwise falls back to `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.
+- When production is eventually armed, the workflow also requires `EKS_CLUSTER_PROD` and reads it from the GitHub `production` environment variable first, then the same-named secret if needed. The repo’s documented production region remains `us-east-1`.
 - Anthropic is optional at deploy time. The UI exposes Claude models, but the backend returns a clear configuration error if the key is missing.
-- OpenAI-backed dev/prod deploys emit structured JSON logs with request IDs, trace IDs, capability snapshots, tool activity, and model-run summaries. See [`docs/LOGGING.md`](/home/jack/workspace/supplie-demo-issue5/docs/LOGGING.md).
+- OpenAI-backed dev deploys, and future production deploys once enabled, emit structured JSON logs with request IDs, trace IDs, capability snapshots, tool activity, and model-run summaries. See [`docs/LOGGING.md`](/home/jack/workspace/supplie-demo-issue5/docs/LOGGING.md).
 - On successful deploys, the workflows print recent app logs with `kubectl logs deployment/supplie-demo -n <namespace> --tail=80`.
 - On deploy failures, the workflows run `scripts/collect-k8s-diagnostics.sh` to capture rollout state, pod descriptions, current and previous pod logs, services, ingress, and recent events.

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -68,7 +68,7 @@ kubectl logs deployment/supplie-demo -n supplie-dev | jq 'select(.traceId=="<tra
 
 ## Deploy Diagnostics
 
-Both GitHub Actions deploy workflows now:
+The active dev deploy workflow, and the parked manual-only production workflow once it is intentionally armed, both:
 
 - print a small cluster snapshot after kubeconfig setup
 - print recent application logs after a successful rollout


### PR DESCRIPTION
## Summary
- make the production EKS workflow manual-only and disabled by default
- add an explicit no-op summary when production deploy is not armed
- update canonical deployment docs to reflect the current dev-only operating reality

## Validation
- parsed `.github/workflows/deploy-eks.yml` and `.github/workflows/dev.yml` with PyYAML
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `DEMO_PASSWORD=test_password OPENAI_API_KEY=test-openai-key ANTHROPIC_API_KEY=test-anthropic-key npm run build`

Closes #65